### PR TITLE
revert the width hook change from 302108523

### DIFF
--- a/pyroll/core/roll_pass/base_plugins/width.py
+++ b/pyroll/core/roll_pass/base_plugins/width.py
@@ -5,10 +5,7 @@ from ..roll_pass import RollPass
 
 @RollPass.OutProfile.hookimpl
 def width(roll_pass: RollPass):
-    eq_out_width = roll_pass.in_profile.equivalent_rectangle.width * roll_pass.spread
-    diff = eq_out_width - roll_pass.out_profile.equivalent_rectangle.width
-
-    return roll_pass.out_profile.width + diff
+    return roll_pass.in_profile.width + roll_pass.spread
 
 
 @RollPass.OutProfile.hookimpl

--- a/pyroll/core/roll_pass/base_plugins/width.py
+++ b/pyroll/core/roll_pass/base_plugins/width.py
@@ -5,7 +5,7 @@ from ..roll_pass import RollPass
 
 @RollPass.OutProfile.hookimpl
 def width(roll_pass: RollPass):
-    return roll_pass.in_profile.width + roll_pass.spread
+    return roll_pass.in_profile.width * roll_pass.spread
 
 
 @RollPass.OutProfile.hookimpl


### PR DESCRIPTION
Revert the width hook change since it converges at too high fillings.
Reverted to the old behaviour that $b_1 = b_0 \times \beta$