### PR TITLE
fix pass sequence of input_min.py

### DIFF
--- a/pyroll/ui/cli/res/input_min.py
+++ b/pyroll/ui/cli/res/input_min.py
@@ -15,14 +15,14 @@ sequence = [
         label="Oval I",
         roll=Roll(
             groove=CircularOvalGroove(
-                depth=5e-3,
+                depth=8e-3,
                 r1=6e-3,
                 r2=40e-3
             ),
             nominal_radius=160e-3,
             rotational_frequency=1
         ),
-        gap=1e-3,
+        gap=2e-3,
     ),
     Transport(
         label="I => II",
@@ -33,12 +33,12 @@ sequence = [
         roll=Roll(
             groove=RoundGroove(
                 r1=1e-3,
-                r2=9e-3,
-                depth=8.5e-3
+                r2=12.5e-3,
+                depth=11.5e-3
             ),
             nominal_radius=160e-3,
             rotational_frequency=1
         ),
-        gap=1e-3,
+        gap=2e-3,
     ),
 ]


### PR DESCRIPTION
Fixed the values in input_min.py so that they are computable with real spreading models. Older version failed with Wusatowski by overfilling.