### PR TITLE
fix bug in strain change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyroll"
-version = "1.0.2"
+version = "1.0.3"
 description = "PyRoll rolling simulation framework - core library."
 authors = [
     "Max Weiner <max.weiner@imf.tu-freiberg.de>",

--- a/pyroll/core/roll_pass/base_plugins/strain.py
+++ b/pyroll/core/roll_pass/base_plugins/strain.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 import numpy as np
@@ -7,8 +8,15 @@ from ..roll_pass import RollPass
 
 @RollPass.hookimpl
 def strain_change(roll_pass: RollPass):
-    strain = np.log(roll_pass.in_profile.cross_section.area / roll_pass.out_profile.cross_section.area)
-    return strain
+    strain_change = np.log(roll_pass.in_profile.cross_section.area / roll_pass.out_profile.cross_section.area)
+
+    if strain_change < 0:
+        logging.getLogger(__name__).warning(
+            "Negative strain change occurred. Assuming it to be zero to be able to continue iteration."
+        )
+        return 0
+
+    return strain_change
 
 
 @RollPass.OutProfile.hookimpl


### PR DESCRIPTION
Fix bug in strain change.

If strain in a pass is low, sometimes negative strains occur in the first iteration, were ideal filling is assumed. Negative strains lead to failure of solution procedure. By assuming a negative strain to zero and issue a warning, iteration may continue and work properly.
In further iteration runs, the problem is often resolved, since the groove is underfilled and strain is positive again.