### PR TITLE
Multi materials

### DIFF
--- a/pyroll/core/profile/hookspecs.py
+++ b/pyroll/core/profile/hookspecs.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Iterable, Union
 
 from shapely.geometry import Polygon, LineString
 
@@ -51,7 +52,7 @@ def temperature(profile: Profile) -> float:
 
 
 @Profile.hookspec
-def material(profile: Profile) -> str:
+def material(profile: Profile) -> Union[str, Iterable[str]]:
     """Material identifier string for use in several other hooks to get material properties."""
 
 

--- a/pyroll/utils/hookutils.py
+++ b/pyroll/utils/hookutils.py
@@ -50,7 +50,7 @@ def for_in_profile_types(*keys: str):
 
     def decorator(func):
         if hasattr(func, "for_in_profile_types"):
-            func.for_in_profile_types = func.for_in_profile_types.union(keys)
+            func.for_in_profile_types = func.for_in_profile_types.union(k.lower() for k in keys)
             return func
 
         @makefun.wraps(func)
@@ -60,7 +60,7 @@ def for_in_profile_types(*keys: str):
                 return func(**kwargs)
             return None
 
-        setattr(wrapper, "for_in_profile_types", set(keys))
+        setattr(wrapper, "for_in_profile_types", {k.lower() for k in keys})
 
         return wrapper
 
@@ -87,7 +87,7 @@ def for_out_profile_types(*keys: str):
 
     def decorator(func):
         if hasattr(func, "for_out_profile_types"):
-            func.for_out_profile_types = func.for_out_profile_types.union(keys)
+            func.for_out_profile_types = func.for_out_profile_types.union(k.lower() for k in keys)
             return func
 
         @makefun.wraps(func)
@@ -97,7 +97,7 @@ def for_out_profile_types(*keys: str):
                 return func(**kwargs)
             return None
 
-        setattr(wrapper, "for_out_profile_types", set(keys))
+        setattr(wrapper, "for_out_profile_types", {k.lower() for k in keys})
 
         return wrapper
 
@@ -124,7 +124,7 @@ def for_roll_pass_types(*keys: str):
 
     def decorator(func):
         if hasattr(func, "for_roll_pass_types"):
-            func.for_roll_pass_types = func.for_roll_pass_types.union(keys)
+            func.for_roll_pass_types = func.for_roll_pass_types.union(k.lower() for k in keys)
             return func
 
         @makefun.wraps(func)
@@ -134,7 +134,7 @@ def for_roll_pass_types(*keys: str):
                 return func(**kwargs)
             return None
 
-        setattr(wrapper, "for_roll_pass_types", set(keys))
+        setattr(wrapper, "for_roll_pass_types", {k.lower() for k in keys})
 
         return wrapper
 

--- a/pyroll/utils/hookutils.py
+++ b/pyroll/utils/hookutils.py
@@ -12,7 +12,7 @@ def for_materials(*keys: str):
     This decorator can be applied multiple times.
 
     :param keys: one or more string keys that represent materials this hook implementation should apply to
-    :returns: the hook result, if the value of ``profile.material`` is in ``keys``, else ``None``
+    :returns: the hook result, if one item of ``profile.material`` is in ``keys``, else ``None``
     """
 
     def decorator(func):
@@ -24,7 +24,11 @@ def for_materials(*keys: str):
         def wrapper(**kwargs):
             profile: Profile = kwargs["profile"]
             if hasattr(profile, "material"):
-                if profile.material.lower() in wrapper.for_materials:
+                if isinstance(profile.material, str):
+                    material = {profile.material.lower()}
+                else:
+                    material = {m.lower() for m in profile.material}
+                if wrapper.for_materials.intersection(material):
                     return func(**kwargs)
             return None
 

--- a/tests/utlis/test_for_materials.py
+++ b/tests/utlis/test_for_materials.py
@@ -1,0 +1,30 @@
+import pyroll.core
+from pyroll.utils import for_materials
+
+
+class DummyProfile:
+    def __init__(self, material):
+        self.material = material
+
+
+def test_for_materials_single():
+    def dummy_func(profile):
+        return 1
+
+    dec_func = for_materials("testmat1", "testmat2")(dummy_func)
+
+    assert dec_func(DummyProfile("testmat1")) == 1
+    assert dec_func(DummyProfile("testmat2")) == 1
+    assert dec_func(DummyProfile("wrong_mat")) is None
+
+
+def test_for_materials_multi():
+    def dummy_func(profile):
+        return 1
+
+    dec_func = for_materials("testmat1", "testmat2")(dummy_func)
+
+    assert dec_func(DummyProfile(["testmat1", "wrong_mat"])) == 1
+    assert dec_func(DummyProfile(["testmat2", "wrong_mat"])) == 1
+    assert dec_func(DummyProfile(["testmat1", "testmat2"])) == 1
+    assert dec_func(DummyProfile(["wrong_mat"])) is None


### PR DESCRIPTION
# What?

- Allow for usage of multiple material keys in `Profile.material` by using an iterable of strings as value. Old syntax with single string remains valid and is internally handled by `@for_materials` accordingly.
- Add `lower()` to profile and roll pass types decorators.

# Why?

Need for possibility to define broader terms for materials like `profile.material = ["steel", "carbon_steel", "C45"]` to allow for material databases to give common data for material groups.
