### PR TITLE
Fix shapely

### DIFF
--- a/pyroll/core/shapes.py
+++ b/pyroll/core/shapes.py
@@ -1,16 +1,15 @@
 from typing import Iterable
 
 import numpy as np
-import shapely.geometry
 from shapely.ops import linemerge
 import logging
 
 from pyroll.core.repr import ReprMixin
-from shapely.geometry import MultiLineString, Point
+from shapely import MultiLineString, Point, Polygon, LineString
 
 
 # noinspection PyAbstractClass
-class Polygon(shapely.geometry.Polygon, ReprMixin):
+class PatchedPolygon(Polygon):
     @property
     def height(self) -> float:
         """Computes the height of the bounding box."""
@@ -35,8 +34,15 @@ class Polygon(shapely.geometry.Polygon, ReprMixin):
             "area": self.area,
         }
 
-    __str__ = ReprMixin.__str__
 
+Polygon.height = PatchedPolygon.height
+Polygon.width = PatchedPolygon.width
+Polygon.perimeter = PatchedPolygon.perimeter
+Polygon.__attrs__ = PatchedPolygon.__attrs__
+Polygon.__str__ = ReprMixin.__str__
+Polygon.__repr__ = ReprMixin.__repr__
+Polygon._repr_html_ = ReprMixin._repr_html_
+Polygon._repr_pretty_ = ReprMixin._repr_pretty_
 
 _RECTANGLE_CORNERS = np.asarray([
     (-0.5, -0.5),
@@ -67,10 +73,7 @@ def rectangle(width: float, height: float):
     return rect
 
 
-shapely.geometry.Polygon = Polygon
-
-
-class LineString(shapely.geometry.LineString, ReprMixin):
+class PatchedLineString(LineString):
     @property
     def depth(self) -> float:
         """Computes the height of the bounding box."""
@@ -89,10 +92,14 @@ class LineString(shapely.geometry.LineString, ReprMixin):
             "length": self.length,
         }
 
-    __str__ = ReprMixin.__str__
 
-
-shapely.geometry.LineString = LineString
+LineString.depth = PatchedLineString.depth
+LineString.width = PatchedLineString.width
+LineString.__attrs__ = PatchedLineString.__attrs__
+LineString.__str__ = ReprMixin.__str__
+LineString.__repr__ = ReprMixin.__repr__
+LineString._repr_html_ = ReprMixin._repr_html_
+LineString._repr_pretty_ = ReprMixin._repr_pretty_
 
 
 def linemerge_if_multi(lines):

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -1,6 +1,10 @@
 import logging
+import webbrowser
 from pathlib import Path
-from pyroll.core import Profile, Roll, RollPass, Transport, RoundGroove, CircularOvalGroove, PassSequence
+
+import numpy as np
+
+from pyroll.core import Profile, Roll, RollPass, Transport, RoundGroove, CircularOvalGroove, PassSequence, SquareGroove
 
 
 def test_solve_min(tmp_path: Path, caplog):
@@ -11,7 +15,8 @@ def test_solve_min(tmp_path: Path, caplog):
         temperature=1200 + 273.15,
         strain=0,
         material=["C45", "steel"],
-        flow_stress=100e6
+        flow_stress=100e6,
+        length=1,
     )
 
     sequence = PassSequence([
@@ -45,6 +50,23 @@ def test_solve_min(tmp_path: Path, caplog):
             ),
             gap=2e-3,
         ),
+        Transport(
+            label="II => III",
+            duration=1
+        ),
+        RollPass(
+            label="Oval III",
+            roll=Roll(
+                groove=CircularOvalGroove(
+                    depth=6e-3,
+                    r1=6e-3,
+                    r2=35e-3
+                ),
+                nominal_radius=160e-3,
+                rotational_frequency=1
+            ),
+            gap=2e-3,
+        ),
     ])
 
     try:
@@ -52,3 +74,16 @@ def test_solve_min(tmp_path: Path, caplog):
     finally:
         print("\nLog:")
         print(caplog.text)
+
+    try:
+        import pyroll.report
+
+        report = pyroll.report.report(sequence)
+
+        report_file = tmp_path / "report.html"
+        report_file.write_text(report)
+        print(report_file)
+        webbrowser.open(report_file.as_uri())
+
+    except ImportError:
+        pass


### PR DESCRIPTION
Due to use of `__new__` constructor for geometries in shapely 2.0 old monkeypatches did not work anymore.
Old concept of replacement by derived classes does not work anymore, instead direct patching.