### PR TITLE
Three-Roll Passes

### DIFF
--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -6,7 +6,7 @@ from .grooves import BoxGroove, ConstrictedBoxGroove, SquareGroove, DiamondGroov
     CircularOvalGroove, FlatOvalGroove, SwedishOvalGroove, ConstrictedSwedishOvalGroove, Oval3RadiiGroove, \
     Oval3RadiiFlankedGroove, SplineGroove, GenericElongationGroove, FlatGroove
 from .transport import Transport
-from .roll_pass import RollPass, DeformationUnit
+from .roll_pass import RollPass, DeformationUnit, ThreeRollPass
 from .unit import Unit
 from .roll import Roll
 from .profile import Profile
@@ -25,5 +25,7 @@ root_hooks.update({
     Unit.OutProfile.length,
     Unit.OutProfile.types,
     Unit.OutProfile.t,
+    Unit.OutProfile.height,
+    Unit.OutProfile.width,
     PassSequence.total_elongation,
 })

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -1,5 +1,5 @@
 ROLL_PASS_AUTO_ROTATION = True
 """Whether to enable automatic rotation of incoming profiles in roll passes by default."""
 
-GROOVE_PADDING = 0.2
+GROOVE_PADDING = 0.5
 """Fraction of the total groove width that is added at the sides of the groove contour to represent the roll face."""

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -1,2 +1,5 @@
 ROLL_PASS_AUTO_ROTATION = True
 """Whether to enable automatic rotation of incoming profiles in roll passes by default."""
+
+GROOVE_PADDING = 0.2
+"""Fraction of the total groove width that is added at the sides of the groove contour to represent the roll face."""

--- a/pyroll/core/grooves/generic_elongation.py
+++ b/pyroll/core/grooves/generic_elongation.py
@@ -167,7 +167,7 @@ class GenericElongationGroove(GrooveBase, ReprMixin):
 
     @property
     def width(self) -> float:
-        return 2.2 * self.z1
+        return 2 * self.z1
 
     @property
     def depth(self) -> float:

--- a/pyroll/core/grooves/spline.py
+++ b/pyroll/core/grooves/spline.py
@@ -50,7 +50,7 @@ class SplineGroove(GrooveBase):
         self._contour_points = contour_points
         self._contour_line = LineString(contour_points)
         self._cross_section = Polygon(self._contour_line)
-        self._width = half_width * 1.1
+        self._width = half_width * 2
 
         self._depth = np.max(contour_points[:, 1])
 

--- a/pyroll/core/hooks.py
+++ b/pyroll/core/hooks.py
@@ -299,7 +299,7 @@ class HookHost(ReprMixin, LogMixin, metaclass=_HookHostMeta):
     def __init__(self):
         self.__cache__ = dict()
 
-    def clear_hook_cache(self):
+    def clear_cache(self):
         """
         Clears the cache of hook function results.
         """

--- a/pyroll/core/profile/hookimpls.py
+++ b/pyroll/core/profile/hookimpls.py
@@ -19,13 +19,13 @@ def width(self: Profile):
 @Profile.height
 def height_3fold(self: Profile):
     if "3fold" in self.types:
-        return self.cross_section.centroid.y - self.cross_section.bounds[1]
+        return (self.cross_section.centroid.y - self.cross_section.bounds[1]) * 2
 
 
 @Profile.width
 def width_3fold(self: Profile):
     if "3fold" in self.types:
-        return self.cross_section.bounds[3] - self.cross_section.centroid.y
+        return (self.cross_section.bounds[3] - self.cross_section.centroid.y) * 2
 
 
 @Profile.length

--- a/pyroll/core/profile/hookimpls.py
+++ b/pyroll/core/profile/hookimpls.py
@@ -16,6 +16,18 @@ def width(self: Profile):
         return np.abs(self.cross_section.bounds[2] - self.cross_section.bounds[0])
 
 
+@Profile.height
+def height_3fold(self: Profile):
+    if "3fold" in self.types:
+        return self.cross_section.centroid.y - self.cross_section.bounds[1]
+
+
+@Profile.width
+def width_3fold(self: Profile):
+    if "3fold" in self.types:
+        return self.cross_section.bounds[3] - self.cross_section.centroid.y
+
+
 @Profile.length
 def length(self: Profile):
     return 0

--- a/pyroll/core/roll/hookimpls.py
+++ b/pyroll/core/roll/hookimpls.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .roll import Roll
-from .. import GROOVE_PADDING
+from ..config import GROOVE_PADDING
 
 
 @Roll.working_radius

--- a/pyroll/core/roll/hookimpls.py
+++ b/pyroll/core/roll/hookimpls.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from .roll import Roll
+from .. import GROOVE_PADDING
 
 
 @Roll.working_radius
@@ -35,15 +36,17 @@ def rotational_frequency(self: Roll):
 
 @Roll.width
 def width(self: Roll):
-    return self.groove.width
+    return self.groove.width * (1 + 2 * GROOVE_PADDING)
 
 
 @Roll.contour_points
 def contour_points(self: Roll):
     points = np.zeros((len(self.groove.contour_points) + 2, 2), dtype=float)
     points[1:-1] = self.groove.contour_points
-    points[0, 0] = - 0.6 * self.groove.width
-    points[-1, 0] = 0.6 * self.groove.width
+
+    z_max = self.groove.width * (0.5 + GROOVE_PADDING)
+    points[0, 0] = -z_max
+    points[-1, 0] = z_max
 
     return points
 

--- a/pyroll/core/roll/roll.py
+++ b/pyroll/core/roll/roll.py
@@ -108,8 +108,8 @@ class Roll(HookHost):
 
         self._contour_line = None
 
-    def clear_hook_cache(self):
-        super().clear_hook_cache()
+    def clear_cache(self):
+        super().clear_cache()
         self._contour_line = None
 
     @property

--- a/pyroll/core/roll_pass/__init__.py
+++ b/pyroll/core/roll_pass/__init__.py
@@ -1,4 +1,5 @@
 from .roll_pass import RollPass
+from .three_roll_pass import ThreeRollPass
 from .deformation_unit import DeformationUnit
 
 from . import hookimpls

--- a/pyroll/core/roll_pass/hookimpls/profile.py
+++ b/pyroll/core/roll_pass/hookimpls/profile.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+from shapely.affinity import rotate
 from shapely.geometry import Polygon
 from shapely.ops import clip_by_rect
 
@@ -69,6 +70,23 @@ def cross_section(self: RollPass.OutProfile) -> Polygon:
         )
 
     return clip_by_rect(poly, -self.width / 2, -math.inf, self.width / 2, math.inf)
+
+
+@ThreeRollPass.OutProfile.cross_section
+def cross_section(self: ThreeRollPass.OutProfile) -> Polygon:
+    poly = Polygon(np.concatenate([cl.coords for cl in self.roll_pass.contour_lines]))
+
+    if self.width > self.roll_pass.roll.width:
+        raise ValueError(
+            "Profile's width can not be larger than its contour lines."
+            "May be caused by critical overfilling."
+        )
+
+    for _ in range(3):
+        poly = clip_by_rect(poly, -math.inf, -math.inf, math.inf, self.width / 2)
+        poly = rotate(poly, angle=120, origin=(0, 0))
+
+    return poly
 
 
 @RollPass.OutProfile.types

--- a/pyroll/core/roll_pass/hookimpls/profile.py
+++ b/pyroll/core/roll_pass/hookimpls/profile.py
@@ -45,18 +45,17 @@ def filling_ratio(self: RollPass.OutProfile):
 
 @RollPass.OutProfile.cross_section
 def cross_section(self: RollPass.OutProfile) -> Polygon:
-    poly = Polygon(np.concatenate([
-        self.roll_pass.upper_contour_line.coords,
-        self.roll_pass.lower_contour_line.coords
-    ]))
+    poly = Polygon(np.concatenate([cl.coords for cl in self.roll_pass.contour_lines]))
 
     if (
             # one percent tolerance to bypass discretization issues
             - self.width / 2 < poly.bounds[0] * 1.01
             or self.width / 2 > poly.bounds[2] * 1.01
     ):
-        raise ValueError("Profile's width can not be larger than its contour lines."
-                         "May be caused by critical overfilling.")
+        raise ValueError(
+            "Profile's width can not be larger than its contour lines."
+            "May be caused by critical overfilling."
+            )
 
     return clip_by_rect(poly, -self.width / 2, -math.inf, self.width / 2, math.inf)
 

--- a/pyroll/core/roll_pass/hookimpls/profile.py
+++ b/pyroll/core/roll_pass/hookimpls/profile.py
@@ -26,7 +26,7 @@ def strain(self: RollPass.OutProfile):
 
 @ThreeRollPass.OutProfile.width
 def width(self: ThreeRollPass.OutProfile):
-    return self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 4
+    return 2 / 3 * np.sqrt(3) * (self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 2)
 
 
 @RollPass.OutProfile.width
@@ -52,7 +52,7 @@ def filling_ratio(self: RollPass.OutProfile):
 
 @ThreeRollPass.OutProfile.filling_ratio
 def filling_ratio(self: ThreeRollPass.OutProfile):
-    return self.width / (self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 4)
+    return self.width / (2 / 3 * np.sqrt(3) * (self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 2))
 
 
 @RollPass.OutProfile.cross_section

--- a/pyroll/core/roll_pass/hookimpls/profile.py
+++ b/pyroll/core/roll_pass/hookimpls/profile.py
@@ -5,6 +5,7 @@ from shapely.geometry import Polygon
 from shapely.ops import clip_by_rect
 
 from ..roll_pass import RollPass
+from ..three_roll_pass import ThreeRollPass
 
 
 @RollPass.InProfile.x
@@ -20,6 +21,11 @@ def exit_point(self: RollPass.OutProfile):
 @RollPass.OutProfile.strain
 def strain(self: RollPass.OutProfile):
     return self.roll_pass.in_profile.strain + self.roll_pass.strain
+
+
+@ThreeRollPass.OutProfile.width
+def width(self: ThreeRollPass.OutProfile):
+    return self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 4
 
 
 @RollPass.OutProfile.width
@@ -43,6 +49,11 @@ def filling_ratio(self: RollPass.OutProfile):
     return self.width / self.roll_pass.roll.groove.usable_width
 
 
+@ThreeRollPass.OutProfile.filling_ratio
+def filling_ratio(self: ThreeRollPass.OutProfile):
+    return self.width / (self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 4)
+
+
 @RollPass.OutProfile.cross_section
 def cross_section(self: RollPass.OutProfile) -> Polygon:
     poly = Polygon(np.concatenate([cl.coords for cl in self.roll_pass.contour_lines]))
@@ -55,7 +66,7 @@ def cross_section(self: RollPass.OutProfile) -> Polygon:
         raise ValueError(
             "Profile's width can not be larger than its contour lines."
             "May be caused by critical overfilling."
-            )
+        )
 
     return clip_by_rect(poly, -self.width / 2, -math.inf, self.width / 2, math.inf)
 

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from ..roll_pass import RollPass
 from ..three_roll_pass import ThreeRollPass
-from ... import GROOVE_PADDING
+from ...config import GROOVE_PADDING
 
 
 @RollPass.Roll.roll_torque

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -37,11 +37,12 @@ def contour_points(self: ThreeRollPass.Roll):
     """With flanks of 120°"""
     points = np.zeros((len(self.groove.contour_points) + 2, 2), dtype=float)
     points[1:-1] = self.groove.contour_points
-    z_max = self.groove.width * (0.5 + GROOVE_PADDING)
+    pad = self.groove.width * GROOVE_PADDING
+    z_max = 0.5 * self.groove.width + pad
     points[0, 0] = -z_max
     points[-1, 0] = z_max
 
-    y = GROOVE_PADDING * self.groove.width * np.tan(np.pi / 6)
+    y = pad * np.tan(np.pi / 6)
     points[0, 1] = y
     points[-1, 1] = y
 

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ..roll_pass import RollPass
+from ..three_roll_pass import ThreeRollPass
 
 
 @RollPass.Roll.roll_torque
@@ -28,3 +29,18 @@ def contact_area(self: RollPass.Roll):
 @RollPass.Roll.center
 def center(self: RollPass.Roll):
     return np.array([0, self.roll_pass.gap / 2 + self.nominal_radius])
+
+
+@ThreeRollPass.Roll.contour_points
+def contour_points(self: ThreeRollPass.Roll):
+    """With flanks of 120°"""
+    points = np.zeros((len(self.groove.contour_points) + 2, 2), dtype=float)
+    points[1:-1] = self.groove.contour_points
+    points[0, 0] = -0.6 * self.groove.width
+    points[-1, 0] = 0.6 * self.groove.width
+
+    y = 0.1 * self.groove.width * np.sin(np.pi / 6)
+    points[0, 1] = y
+    points[-1, 1] = y
+
+    return points

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from ..roll_pass import RollPass
 from ..three_roll_pass import ThreeRollPass
+from ... import GROOVE_PADDING
 
 
 @RollPass.Roll.roll_torque
@@ -36,10 +37,11 @@ def contour_points(self: ThreeRollPass.Roll):
     """With flanks of 120°"""
     points = np.zeros((len(self.groove.contour_points) + 2, 2), dtype=float)
     points[1:-1] = self.groove.contour_points
-    points[0, 0] = -0.6 * self.groove.width
-    points[-1, 0] = 0.6 * self.groove.width
+    z_max = self.groove.width * (0.5 + GROOVE_PADDING)
+    points[0, 0] = -z_max
+    points[-1, 0] = z_max
 
-    y = 0.1 * self.groove.width * np.sin(np.pi / 6)
+    y = GROOVE_PADDING * self.groove.width * np.tan(np.pi / 6)
     points[0, 1] = y
     points[-1, 1] = y
 

--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -48,6 +48,16 @@ def height(self):
         return self.gap + 2 * self.roll.groove.depth
 
 
+@ThreeRollPass.height
+def height3(self):
+    if self.has_set_or_cached("gap"):
+        return 2 * (
+                self.roll.groove.width / 2 / np.sqrt(3)
+                + self.gap / np.sqrt(3)
+                + self.roll.groove.depth
+        )
+
+
 @RollPass.volume
 def volume(self: RollPass):
     return (self.in_profile.cross_section.area + 2 * self.out_profile.cross_section.area

--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ..roll_pass import RollPass
+from ..three_roll_pass import ThreeRollPass
 from ...rotator import Rotator
 from ...grooves import GenericElongationGroove
 
@@ -26,7 +27,7 @@ def detect_already_rotated(self: RollPass):
 
 @RollPass.roll_force
 def roll_force(self: RollPass):
-    return (self.in_profile.flow_stress + 2 * self.out_profile.flow_stress) / 3 * self.contact_area / 2
+    return (self.in_profile.flow_stress + 2 * self.out_profile.flow_stress) / 3 * self.roll.contact_area
 
 
 @RollPass.tip_width
@@ -35,9 +36,16 @@ def tip_width(self):
         return self.roll.groove.usable_width + self.gap / 2 / np.tan(self.roll.groove.alpha1)
 
 
+@RollPass.gap
+def gap(self: RollPass):
+    if self.has_set_or_cached("height"):
+        return self.height - 2 * self.roll.groove.depth
+
+
 @RollPass.height
 def height(self):
-    return self.gap + 2 * self.roll.groove.depth
+    if self.has_set_or_cached("gap"):
+        return self.gap + 2 * self.roll.groove.depth
 
 
 @RollPass.volume
@@ -55,6 +63,11 @@ def surface_area(self: RollPass):
 @RollPass.contact_area
 def contact_area(self: RollPass):
     return 2 * self.roll.contact_area
+
+
+@ThreeRollPass.contact_area
+def contact_area3(self: ThreeRollPass):
+    return 3 * self.roll.contact_area
 
 
 @RollPass.velocity

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -82,7 +82,7 @@ class RollPass(DiskElementUnit, DeformationUnit):
     def types(self):
         """A tuple of keywords to specify the shape types of this roll pass.
         Shortcut to ``self.groove.types``."""
-        return self.roll.groove.types
+        return set(self.roll.groove.types)
 
     @property
     def disk_elements(self) -> List['RollPass.DiskElement']:

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -64,19 +64,19 @@ class RollPass(DiskElementUnit, DeformationUnit):
         self.roll = self.Roll(roll, self)
         """The working roll of this pass (equal upper and lower)."""
 
-    def local_height(self, z: float) -> float:
-        """Returns the local height of the roll pass in the high point."""
-        return 2 * self.roll.groove.local_depth(z) + self.gap
+        self._contour_lines = None
 
     @property
-    def upper_contour_line(self) -> LineString:
-        """Contour line object of the upper working roll."""
-        return translate(self.roll.contour_line, yoff=self.gap / 2)
+    def contour_lines(self) -> List[LineString]:
+        """List of line strings bounding the roll pass at the high point."""
+        if self._contour_lines:
+            return self._contour_lines
 
-    @property
-    def lower_contour_line(self) -> LineString:
-        """Contour line object of the lower working roll."""
-        return rotate(self.upper_contour_line, angle=180, origin=(0, 0))
+        upper = translate(self.roll.contour_line, yoff=self.gap / 2)
+        lower = rotate(upper, angle=180, origin=(0, 0))
+
+        self._contour_lines = [upper, lower]
+        return self._contour_lines
 
     @property
     def types(self):
@@ -111,6 +111,7 @@ class RollPass(DiskElementUnit, DeformationUnit):
     def clear_hook_cache(self):
         super().clear_hook_cache()
         self.roll.clear_hook_cache()
+        self._contour_lines = None
 
     class Profile(DiskElementUnit.Profile, DeformationUnit.Profile):
         """Represents a profile in context of a roll pass."""

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -108,9 +108,9 @@ class RollPass(DiskElementUnit, DeformationUnit):
 
         return np.concatenate([super_results, roll_results], axis=0)
 
-    def clear_hook_cache(self):
-        super().clear_hook_cache()
-        self.roll.clear_hook_cache()
+    def clear_cache(self):
+        super().clear_cache()
+        self.roll.clear_cache()
         self._contour_lines = None
 
     class Profile(DiskElementUnit.Profile, DeformationUnit.Profile):

--- a/pyroll/core/roll_pass/three_roll_pass.py
+++ b/pyroll/core/roll_pass/three_roll_pass.py
@@ -16,6 +16,7 @@ class ThreeRollPass(RollPass):
             return self._contour_lines
 
         lower = rotate(translate(self.roll.contour_line, yoff=self.gap / 2), angle=180, origin=(0, 0))
+        lower = LineString(lower.coords[::-1])  # get back coordinate order
         right = rotate(lower, angle=120, origin=(0, 0))
         left = rotate(lower, angle=-120, origin=(0, 0))
 

--- a/pyroll/core/roll_pass/three_roll_pass.py
+++ b/pyroll/core/roll_pass/three_roll_pass.py
@@ -1,5 +1,6 @@
 from typing import List, cast
 
+import numpy as np
 from shapely.affinity import translate, rotate
 from shapely.geometry import LineString
 
@@ -15,7 +16,8 @@ class ThreeRollPass(RollPass):
         if self._contour_lines:
             return self._contour_lines
 
-        lower = rotate(translate(self.roll.contour_line, yoff=self.gap / 2), angle=180, origin=(0, 0))
+        shift = self.roll.groove.width / 2 / np.sqrt(3) + self.gap / np.sqrt(3)
+        lower = rotate(translate(self.roll.contour_line, yoff=shift), angle=180, origin=(0, 0))
         lower = LineString(lower.coords[::-1])  # get back coordinate order
         right = rotate(lower, angle=120, origin=(0, 0))
         left = rotate(lower, angle=-120, origin=(0, 0))
@@ -56,7 +58,7 @@ class ThreeRollPass(RollPass):
         @property
         def roll_pass(self) -> 'ThreeRollPass':
             """Reference to the roll pass."""
-            return cast(ThreeRollPass, self._roll_pass)
+            return cast(ThreeRollPass, self._roll_pass())
 
     class DiskElement(RollPass.DiskElement):
         """Represents a disk element in a roll pass."""

--- a/pyroll/core/roll_pass/three_roll_pass.py
+++ b/pyroll/core/roll_pass/three_roll_pass.py
@@ -1,0 +1,80 @@
+from typing import List, cast
+
+from shapely.affinity import translate, rotate
+from shapely.geometry import LineString
+
+from ..hooks import Hook
+from ..roll_pass import RollPass
+
+
+class ThreeRollPass(RollPass):
+    """Represents a roll pass."""
+
+    @property
+    def contour_lines(self) -> List[LineString]:
+        if self._contour_lines:
+            return self._contour_lines
+
+        lower = rotate(translate(self.roll.contour_line, yoff=self.gap / 2), angle=180, origin=(0, 0))
+        right = rotate(lower, angle=120, origin=(0, 0))
+        left = rotate(lower, angle=-120, origin=(0, 0))
+
+        self._contour_lines = [left, lower, right]
+        return self._contour_lines
+
+    @property
+    def types(self):
+        """A tuple of keywords to specify the shape types of this roll pass.
+        Shortcut to ``self.groove.types``."""
+        return set(self.roll.groove.types) | {"3fold"}
+
+    @property
+    def disk_elements(self) -> List['RollPass.DiskElement']:
+        """A list of disk elements used to subdivide this unit."""
+        return list(self._subunits)
+
+    class Profile(RollPass.Profile):
+        """Represents a profile in context of a roll pass."""
+
+        @property
+        def roll_pass(self) -> 'RollPass':
+            """Reference to the roll pass. Alias for ``self.unit``."""
+            return cast(RollPass, self.unit)
+
+    class InProfile(Profile, RollPass.InProfile):
+        """Represents an incoming profile of a roll pass."""
+
+    class OutProfile(Profile, RollPass.OutProfile):
+        """Represents an outgoing profile of a roll pass."""
+
+        filling_ratio = Hook[float]()
+
+    class Roll(RollPass.Roll):
+        """Represents a roll applied in a :py:class:`ThreeRollPass`."""
+
+        @property
+        def roll_pass(self) -> 'ThreeRollPass':
+            """Reference to the roll pass."""
+            return cast(ThreeRollPass, self._roll_pass)
+
+    class DiskElement(RollPass.DiskElement):
+        """Represents a disk element in a roll pass."""
+
+        @property
+        def roll_pass(self) -> 'ThreeRollPass':
+            """Reference to the roll pass. Alias for ``self.parent``."""
+            return cast(ThreeRollPass, self.parent)
+
+        class Profile(RollPass.DiskElement.Profile):
+            """Represents a profile in context of a disk element unit."""
+
+            @property
+            def disk_element(self) -> 'ThreeRollPass.DiskElement':
+                """Reference to the disk element. Alias for ``self.unit``"""
+                return cast(ThreeRollPass.DiskElement, self.unit)
+
+        class InProfile(Profile, RollPass.DiskElement.InProfile):
+            """Represents an incoming profile of a disk element unit."""
+
+        class OutProfile(Profile, RollPass.DiskElement.OutProfile):
+            """Represents an outgoing profile of a disk element unit."""

--- a/pyroll/core/rotator/hookimpls.py
+++ b/pyroll/core/rotator/hookimpls.py
@@ -65,3 +65,9 @@ def box_oval(self: Rotator):
 def round_flat(self: Rotator):
     if "round" in self.in_profile.types and "flat" in self.next_roll_pass.types:
         return 90
+
+
+@Rotator.rotation
+def three_roll_pass(self: Rotator):
+    if "3fold" in self.next_roll_pass.types:
+        return 180

--- a/pyroll/core/unit/unit.py
+++ b/pyroll/core/unit/unit.py
@@ -94,10 +94,10 @@ class Unit(HookHost):
 
         return np.concatenate([in_profile_results, self_results, out_profile_results], axis=0)
 
-    def clear_hook_cache(self):
-        self.in_profile.clear_hook_cache()
-        super().clear_hook_cache()
-        self.out_profile.clear_hook_cache()
+    def clear_cache(self):
+        self.in_profile.clear_cache()
+        super().clear_cache()
+        self.out_profile.clear_cache()
 
     def _solve_subunits(self):
         last_profile = self.in_profile
@@ -120,7 +120,7 @@ class Unit(HookHost):
         old_values = np.nan
 
         for i in range(1, self.max_iteration_count):
-            self.clear_hook_cache()
+            self.clear_cache()
             self._solve_subunits()
             current_values = self.get_root_hook_results()
 

--- a/tests/hooks/test_hook_functions.py
+++ b/tests/hooks/test_hook_functions.py
@@ -112,7 +112,7 @@ def test_cache():
     assert host.hook1 == 21
     assert host.has_cached("hook1")
 
-    host.clear_hook_cache()
+    host.clear_cache()
 
     assert not host.has_cached("hook1")
     assert host.hook1 == 42

--- a/tests/test_solve3.py
+++ b/tests/test_solve3.py
@@ -1,0 +1,72 @@
+import logging
+import webbrowser
+from pathlib import Path
+
+import numpy as np
+
+from pyroll.core import Profile, Roll, ThreeRollPass, Transport, RoundGroove, CircularOvalGroove, PassSequence, SquareGroove
+
+
+def test_solve3(tmp_path: Path, caplog):
+    caplog.set_level(logging.DEBUG, logger="pyroll")
+
+    in_profile = Profile.round(
+        diameter=55e-3,
+        temperature=1200 + 273.15,
+        strain=0,
+        material=["C45", "steel"],
+        flow_stress=100e6,
+        length=1,
+    )
+
+    sequence = PassSequence([
+        ThreeRollPass(
+            label="Oval I",
+            roll=Roll(
+                groove=CircularOvalGroove(
+                    depth=8e-3,
+                    r1=6e-3,
+                    r2=40e-3
+                ),
+                nominal_radius=160e-3,
+                rotational_frequency=1
+            ),
+            gap=2e-3,
+        ),
+        Transport(
+            label="I => II",
+            duration=1
+        ),
+        ThreeRollPass(
+            label="Round II",
+            roll=Roll(
+                groove=RoundGroove(
+                    r1=3e-3,
+                    r2=25e-3,
+                    depth=11e-3
+                ),
+                nominal_radius=160e-3,
+                rotational_frequency=1
+            ),
+            gap=2e-3,
+        ),
+    ])
+
+    try:
+        sequence.solve(in_profile)
+    finally:
+        print("\nLog:")
+        print(caplog.text)
+
+    try:
+        import pyroll.report
+
+        report = pyroll.report.report(sequence)
+
+        report_file = tmp_path / "report.html"
+        report_file.write_text(report)
+        print(report_file)
+        webbrowser.open(report_file.as_uri())
+
+    except ImportError:
+        pass


### PR DESCRIPTION
- added a new `ThreeRollPass` class to represent roll passes with three working rolls
- implemented geometric core routines for their representation and instantiation
- removed `RollPass.upper_contour_line` and `RollPass.lower_contour_line` properties and replaced them with a sequential `RollPass.contour_lines`