### PR TITLE
Bug Fix: 2 Pi

### DIFF
--- a/pyroll/core/roll/hookimpls.py
+++ b/pyroll/core/roll/hookimpls.py
@@ -21,12 +21,12 @@ def max_radius(self: Roll):
 
 @Roll.roll_power
 def roll_power(self: Roll):
-    return self.roll_torque * self.rotational_frequency
+    return self.roll_torque * self.rotational_frequency * 2 * np.pi
 
 
 @Roll.surface_velocity
 def surface_velocity(self: Roll):
-    return self.rotational_frequency * self.nominal_radius
+    return self.rotational_frequency * self.nominal_radius * 2 * np.pi
 
 
 @Roll.rotational_frequency

--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -81,7 +81,7 @@ def contact_area3(self: ThreeRollPass):
 
 @RollPass.velocity
 def velocity(self: RollPass):
-    return self.roll.working_radius * self.roll.rotational_frequency
+    return self.roll.working_radius * self.roll.rotational_frequency * 2 * np.pi
 
 
 @RollPass.duration


### PR DESCRIPTION
In some hooks on 'Roll' and 'RollPass' the value 2 Pi was missing.