### PR TITLE
Change Configuration

### DIFF
--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -22,6 +22,7 @@ from .rotator import Rotator
 from .sequence import PassSequence
 from .hooks import Hook, HookHost, HookFunction, root_hooks
 from .disk_elements import DiskElementUnit
+from .config import Config, config
 
 root_hooks.update(
     {

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -1,14 +1,76 @@
-ROLL_PASS_AUTO_ROTATION = True
-"""Whether to enable automatic rotation of incoming profiles in roll passes by default."""
+import os
+from typing import Optional
 
-GROOVE_PADDING = 0.2
-"""Fraction of the total groove width that is added at the sides of the groove contour to represent the roll face."""
 
-DEFAULT_MAX_ITERATION_COUNT = 100
-"""Default maximum count of iterations before aborting the loop."""
+class ConfigValue:
+    def __init__(self, default=None, env_var: Optional[str] = None, env_var_prefix: Optional[str] = None):
+        self.default = default
 
-DEFAULT_ITERATION_PRECISION = 1e-2
-"""Default precision of iteration loops required to break successfully."""
+        self._env_var = env_var
+        self._env_var_prefix = env_var_prefix
 
-ROLL_SURFACE_DISCRETIZATION_COUNT = 100
-"""Count of discrete points used to describe the roll surface."""
+    def __set_name__(self, owner: type, name: str):
+        self.owner = owner
+        self.name = name
+        if not self._env_var_prefix:
+            self._env_var_prefix = self.owner.__module__.upper().replace('.', '_')
+
+    @property
+    def env_var(self):
+        if self._env_var:
+            return self._env_var
+
+        return f"{self._env_var_prefix}_{self.name.upper()}"
+
+    def __get__(self, instance, owner):
+        value = getattr(instance, "_" + self.name, None)
+
+        if value is not None:
+            return value
+
+        value = os.getenv(self.env_var, None)
+
+        if value is not None:
+            return value
+
+        return self.default
+
+    def __set__(self, instance, value):
+        setattr(instance, "_" + self.name, value)
+
+    def __delete__(self, instance):
+        delattr(instance, "_" + self.name)
+
+
+def config(env_var_prefix):
+    def dec(cls):
+        cls_dict = {}
+
+        for n, v in cls.__dict__.items():
+            if not isinstance(v, ConfigValue):
+                cls_dict[n] = ConfigValue(default=v, env_var_prefix=env_var_prefix)
+            else:
+                cls_dict[n] = ConfigValue(default=v.default, env_var_prefix=env_var_prefix)
+
+        cls = type(cls)(cls.__name__, cls.__bases__, cls_dict)
+        return cls()
+
+    return dec
+
+
+@config("PYROLL_CORE")
+class Config:
+    ROLL_PASS_AUTO_ROTATION = True
+    """Whether to enable automatic rotation of incoming profiles in roll passes by default."""
+
+    GROOVE_PADDING = 0.2
+    """Fraction of the total groove width that is added at the sides of the groove contour to represent the roll face."""
+
+    DEFAULT_MAX_ITERATION_COUNT = 100
+    """Default maximum count of iterations before aborting the loop."""
+
+    DEFAULT_ITERATION_PRECISION = 1e-2
+    """Default precision of iteration loops required to break successfully."""
+
+    ROLL_SURFACE_DISCRETIZATION_COUNT = 100
+    """Count of discrete points used to describe the roll surface."""

--- a/pyroll/core/grooves/generic_elongation.py
+++ b/pyroll/core/grooves/generic_elongation.py
@@ -5,7 +5,7 @@ from shapely.geometry import LineString, Polygon
 
 from pyroll.core.grooves import GrooveBase
 from pyroll.core.repr import ReprMixin
-from ..config import GROOVE_PADDING
+from ..config import Config
 
 
 class GenericElongationGroove(GrooveBase, ReprMixin):
@@ -32,7 +32,7 @@ class GenericElongationGroove(GrooveBase, ReprMixin):
             even_ground_width: float = 0,
 
             pad: float = 0,
-            rel_pad: float = GROOVE_PADDING,
+            rel_pad: float = Config.GROOVE_PADDING,
             pad_angle: float = 0,
 
             classifiers: Sequence[str] = ()

--- a/pyroll/core/roll/hookimpls.py
+++ b/pyroll/core/roll/hookimpls.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .roll import Roll
-from ..config import ROLL_SURFACE_DISCRETIZATION_COUNT
+from ..config import Config
 
 
 @Roll.working_radius
@@ -48,8 +48,8 @@ def contour_points(self: Roll):
 def surface_x(self: Roll):
     padded_contact_angle = np.arcsin(1.1 * self.contact_length / self.min_radius)
     points = np.concatenate([
-        np.linspace(0, padded_contact_angle, ROLL_SURFACE_DISCRETIZATION_COUNT, endpoint=False),
-        np.linspace(padded_contact_angle, np.pi / 2, ROLL_SURFACE_DISCRETIZATION_COUNT),
+        np.linspace(0, padded_contact_angle, Config.ROLL_SURFACE_DISCRETIZATION_COUNT, endpoint=False),
+        np.linspace(padded_contact_angle, np.pi / 2, Config.ROLL_SURFACE_DISCRETIZATION_COUNT),
     ])
     return self.min_radius * np.sin(np.concatenate([-points[::-1], points[1:]]))
 

--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -5,17 +5,17 @@ from ..three_roll_pass import ThreeRollPass
 from ...rotator import Rotator
 from ...grooves import GenericElongationGroove
 
-from ...config import ROLL_PASS_AUTO_ROTATION
+from ...config import Config
 
 
 @RollPass.rotation
 def auto_rotation(self: RollPass):
-    return ROLL_PASS_AUTO_ROTATION
+    return Config.ROLL_PASS_AUTO_ROTATION
 
 
 @RollPass.rotation
 def detect_already_rotated(self: RollPass):
-    if ROLL_PASS_AUTO_ROTATION and self.parent is not None:
+    if Config.ROLL_PASS_AUTO_ROTATION and self.parent is not None:
         try:
             prev = self.prev
         except IndexError:

--- a/pyroll/core/unit/hookimpls.py
+++ b/pyroll/core/unit/hookimpls.py
@@ -1,4 +1,4 @@
-from ..config import DEFAULT_MAX_ITERATION_COUNT, DEFAULT_ITERATION_PRECISION
+from ..config import Config
 from .unit import Unit
 
 for h in Unit.OutProfile.__hooks__:
@@ -15,12 +15,12 @@ for h in Unit.OutProfile.__hooks__:
 
 @Unit.iteration_precision
 def default_iteration_precision(self: Unit):
-    return DEFAULT_ITERATION_PRECISION
+    return Config.DEFAULT_ITERATION_PRECISION
 
 
 @Unit.max_iteration_count
 def default_max_iteration_count(self: Unit):
-    return DEFAULT_MAX_ITERATION_COUNT
+    return Config.DEFAULT_MAX_ITERATION_COUNT
 
 
 @Unit.volume

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,83 @@
+import os
+
+from pyroll.core import config
+
+
+@config("PYROLL_TEST")
+class Config:
+    _HIDDEN = True
+    hidden = True
+    _hidden = True
+
+    VAR = 1
+    VAR_FLOAT = 1.1
+    VAR_BOOL = True
+    VAR_LIST = ["a", "b"]
+    VAR_TUPLE = ("a", "b")
+    VAR_STR = "abc"
+    VAR_DICT = {}
+
+
+def test_config_default():
+    assert Config.VAR == 1
+
+
+def test_config_env_int(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_VAR", "21")
+
+    assert Config.VAR == 21
+
+
+def test_config_env_float(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_VAR_FLOAT", "3.14")
+
+    assert Config.VAR_FLOAT == 3.14
+
+
+def test_config_env_bool(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_VAR_BOOL", "False")
+
+    assert Config.VAR_BOOL is False
+
+
+def test_config_env_list(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_VAR_LIST", "a,b, c")
+
+    assert Config.VAR_LIST == ["a", "b", "c"]
+
+
+def test_config_env_tuple(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_VAR_TUPLE", "a,b, c")
+
+    assert Config.VAR_TUPLE == ("a", "b", "c")
+
+
+def test_config_env_dict(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_VAR_DICT", "a=1, b=2")
+
+    assert Config.VAR_DICT == {"a": "1", "b": "2"}
+
+
+def test_config_env_str(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_VAR_STR", "def")
+
+    assert Config.VAR_STR == "def"
+
+
+def test_config_explicit():
+    Config.VAR = 42
+
+    assert Config.VAR == 42
+
+
+def test_config_env_and_explicit(monkeypatch):
+    monkeypatch.setenv("PYROLL_TEST_PYROLL_TEST_VAR", "21")
+    Config.VAR = 42
+
+    assert Config.VAR == 42
+
+
+def test_config_hidden():
+    assert not hasattr(type(Config), "_HIDDEN")
+    assert not hasattr(type(Config), "hidden")
+    assert not hasattr(type(Config), "_hidden")


### PR DESCRIPTION
During development of the CLI the need for parsing configuration values for the core and plugins from `config.toml` and perhaps envvars arose.
Module level constants could be altered depending on a heuristic to use all package level constants and such in `pyroll.<package>.config` modules.
But module level constants are error prone regarding imported references, for example one shall always import the config module and not the value itself (`from . import config` instead of `from .config import SOME_VAR`).

A static configuration class would be the better approach, since one could not accidentally import the var itself. To facilitate creation of such classes, the following helper classes and decorators are proposed.
