### PR TITLE
Fix Iteration

### DIFF
--- a/pyroll/core/hooks.py
+++ b/pyroll/core/hooks.py
@@ -301,11 +301,13 @@ class HookHost(ReprMixin, LogMixin, metaclass=_HookHostMeta):
     def __init__(self):
         self.__cache__ = dict()
 
-    def clear_cache(self):
+    def reevaluate_cache(self):
         """
         Clears the cache of hook function results.
         """
-        self.__cache__.clear()
+        for n in list(self.__cache__.keys()):
+            hook = getattr(type(self), n)
+            self.__cache__[n] = hook.get_result(self)
 
     def has_set(self, name: str):
         """Checks whether a value is explicitly set for the hook `name`."""

--- a/pyroll/core/roll/roll.py
+++ b/pyroll/core/roll/roll.py
@@ -111,8 +111,8 @@ class Roll(HookHost):
 
         self._contour_line = None
 
-    def clear_cache(self):
-        super().clear_cache()
+    def reevaluate_cache(self):
+        super().reevaluate_cache()
         self._contour_line = None
 
     @property

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -102,9 +102,9 @@ class RollPass(DiskElementUnit, DeformationUnit):
 
         return np.concatenate([super_results, roll_results], axis=0)
 
-    def clear_cache(self):
-        super().clear_cache()
-        self.roll.clear_cache()
+    def reevaluate_cache(self):
+        super().reevaluate_cache()
+        self.roll.reevaluate_cache()
         self._contour_lines = None
 
     class Profile(DiskElementUnit.Profile, DeformationUnit.Profile):

--- a/pyroll/core/unit/unit.py
+++ b/pyroll/core/unit/unit.py
@@ -103,10 +103,10 @@ class Unit(HookHost):
 
         return np.concatenate([in_profile_results, self_results, out_profile_results], axis=0)
 
-    def clear_cache(self):
-        self.in_profile.clear_cache()
-        super().clear_cache()
-        self.out_profile.clear_cache()
+    def reevaluate_cache(self):
+        self.in_profile.reevaluate_cache()
+        super().reevaluate_cache()
+        self.out_profile.reevaluate_cache()
 
     def _solve_subunits(self):
         last_profile = self.in_profile
@@ -129,8 +129,8 @@ class Unit(HookHost):
         self.init_solve(in_profile)
 
         for i in range(1, self.max_iteration_count):
-            self.clear_cache()
             self._solve_subunits()
+            self.reevaluate_cache()
             current_results = self.get_root_hook_results()
 
             if np.all(

--- a/pyroll/core/unit/unit.py
+++ b/pyroll/core/unit/unit.py
@@ -103,11 +103,6 @@ class Unit(HookHost):
 
         return np.concatenate([in_profile_results, self_results, out_profile_results], axis=0)
 
-    def reevaluate_cache(self):
-        self.in_profile.reevaluate_cache()
-        super().reevaluate_cache()
-        self.out_profile.reevaluate_cache()
-
     def _solve_subunits(self):
         last_profile = self.in_profile
         for u in self._subunits:
@@ -129,8 +124,10 @@ class Unit(HookHost):
         self.init_solve(in_profile)
 
         for i in range(1, self.max_iteration_count):
+            self.in_profile.reevaluate_cache()
             self._solve_subunits()
             self.reevaluate_cache()
+            self.out_profile.reevaluate_cache()
             current_results = self.get_root_hook_results()
 
             if np.all(

--- a/tests/hooks/test_hook_functions.py
+++ b/tests/hooks/test_hook_functions.py
@@ -112,9 +112,8 @@ def test_cache():
     assert host.hook1 == 21
     assert host.has_cached("hook1")
 
-    host.clear_cache()
+    host.reevaluate_cache()
 
-    assert not host.has_cached("hook1")
     assert host.hook1 == 42
 
 


### PR DESCRIPTION
During testing with multiple plugins (Lendl and Wusatowski) problems with caching of equivalent widths and/or widths occurred.

Needs:

- equivalent widths and/or widths must be preserved across iterations for spreading models
- shall not interfere with other plugins

Old approach: add them to `root_hooks`

Problems:

- root hook values on profiles are transferred to next unit
- conflicts with reverse equivalent calculation

New approach: retain cached values, but reevaluate the function cascade in order of dict contents (order of first evaluation)