### PR TITLE
Fixes for error occured after publication of 2.0.0

### DIFF
--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -1,16 +1,6 @@
 from . import shapes as _
 
-from .grooves import (
-    BoxGroove, ConstrictedBoxGroove, UpsetBoxGroove, ConstrictedUpsetBoxGroove,
-    SquareGroove, DiamondGroove, GothicGroove,
-    RoundGroove, FalseRoundGroove,
-    CircularOvalGroove, FlatOvalGroove, SwedishOvalGroove, ConstrictedSwedishOvalGroove, Oval3RadiiGroove,
-    Oval3RadiiFlankedGroove, UpsetOvalGroove, ConstrictedCircularOvalGroove,
-    SplineGroove,
-    GenericElongationGroove,
-    FlatGroove,
-    HexagonalGroove
-)
+from .grooves import *
 from .transport import Transport
 from .roll_pass import RollPass, DeformationUnit, ThreeRollPass
 from .unit import Unit

--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "2.0.0"
+VERSION = "2.0.0.post1"
 
 from . import shapes as _
 

--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -1,5 +1,3 @@
-VERSION = "2.0.0.post1"
-
 from . import shapes as _
 
 from .grooves import (
@@ -23,6 +21,8 @@ from .sequence import PassSequence
 from .hooks import Hook, HookHost, HookFunction, root_hooks
 from .disk_elements import DiskElementUnit
 from .config import Config, config
+
+VERSION = "2.0.1"
 
 root_hooks.update(
     {

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -148,7 +148,7 @@ class Config:
     DEFAULT_MAX_ITERATION_COUNT = 100
     """Default maximum count of iterations before aborting the loop."""
 
-    DEFAULT_ITERATION_PRECISION = 1e-2
+    DEFAULT_ITERATION_PRECISION = 1e-3
     """Default precision of iteration loops required to break successfully."""
 
     ROLL_SURFACE_DISCRETIZATION_COUNT = 100

--- a/pyroll/core/grooves/__init__.py
+++ b/pyroll/core/grooves/__init__.py
@@ -1,10 +1,25 @@
 from .base import GrooveBase
+
 from .spline import SplineGroove
 from .generic_elongation import GenericElongationGroove
+
 from .boxes import BoxGroove, ConstrictedBoxGroove, UpsetBoxGroove, ConstrictedUpsetBoxGroove
+
 from .diamonds import DiamondGroove, SquareGroove, GothicGroove
-from .ovals import CircularOvalGroove, FlatOvalGroove, SwedishOvalGroove, ConstrictedSwedishOvalGroove, \
-    Oval3RadiiGroove, Oval3RadiiFlankedGroove, UpsetOvalGroove, ConstrictedCircularOvalGroove
+
+from .ovals import (
+    CircularOvalGroove,
+    FlatOvalGroove,
+    SwedishOvalGroove,
+    ConstrictedSwedishOvalGroove,
+    Oval3RadiiGroove,
+    Oval3RadiiFlankedGroove,
+    UpsetOvalGroove,
+    ConstrictedCircularOvalGroove
+)
+
 from .rounds import RoundGroove, FalseRoundGroove
+
 from .flat import FlatGroove
+
 from .hexagonal import HexagonalGroove

--- a/pyroll/core/grooves/flat.py
+++ b/pyroll/core/grooves/flat.py
@@ -1,4 +1,3 @@
-import numpy as np
 from numpy import deg2rad
 
 from .generic_elongation import GenericElongationGroove
@@ -28,4 +27,4 @@ class FlatGroove(GenericElongationGroove):
 
     @property
     def classifiers(self):
-        return {"flat",} | super().classifiers
+        return {"flat", } | super().classifiers

--- a/pyroll/core/grooves/generic_elongation.py
+++ b/pyroll/core/grooves/generic_elongation.py
@@ -1,4 +1,4 @@
-from typing import Union, Tuple, Sequence, Optional
+from typing import Union, Sequence, Optional
 
 import numpy as np
 from shapely.geometry import LineString, Polygon

--- a/pyroll/core/grooves/ovals/constricted_circular_oval.py
+++ b/pyroll/core/grooves/ovals/constricted_circular_oval.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from ..generic_elongation import GenericElongationGroove

--- a/pyroll/core/grooves/ovals/oval_3radii.py
+++ b/pyroll/core/grooves/ovals/oval_3radii.py
@@ -1,7 +1,4 @@
-from typing import Optional
 import numpy as np
-from scipy.optimize import minimize, Bounds
-from numpy import sin, cos, tan, pi, array
 from ..generic_elongation import GenericElongationGroove
 from ..generic_elongation_solvers import solve_r123
 

--- a/pyroll/core/grooves/ovals/oval_3radii_flanked.py
+++ b/pyroll/core/grooves/ovals/oval_3radii_flanked.py
@@ -1,8 +1,6 @@
 from typing import Optional
 
 import numpy as np
-from scipy.optimize import brentq
-from numpy import sin, cos, tan, pi
 
 from ..generic_elongation import GenericElongationGroove
 from ..generic_elongation_solvers import solve_r123

--- a/pyroll/core/grooves/rounds/round.py
+++ b/pyroll/core/grooves/rounds/round.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import numpy as np
-from scipy.optimize import root_scalar, minimize_scalar
 
 from ..generic_elongation import GenericElongationGroove
 from ..generic_elongation_solvers import solve_r124
@@ -41,4 +40,4 @@ class RoundGroove(GenericElongationGroove):
 
     @property
     def classifiers(self):
-        return {"round",} | super().classifiers
+        return {"round", } | super().classifiers

--- a/pyroll/core/hooks.py
+++ b/pyroll/core/hooks.py
@@ -84,6 +84,12 @@ class HookFunction:
 
         return extra_args
 
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.hook.remove_function(self)
+
 
 class Hook(Generic[T]):
     """

--- a/pyroll/core/roll_pass/hookimpls/helpers.py
+++ b/pyroll/core/roll_pass/hookimpls/helpers.py
@@ -1,0 +1,24 @@
+import math
+
+import numpy as np
+from shapely import Polygon, clip_by_rect
+from shapely.affinity import rotate
+
+from ..roll_pass import RollPass
+from ..three_roll_pass import ThreeRollPass
+
+
+def out_cross_section(rp: RollPass, width: float) -> Polygon:
+    poly = Polygon(np.concatenate([cl.coords for cl in rp.contour_lines]))
+    return clip_by_rect(poly, -width / 2, -math.inf, width / 2, math.inf)
+
+
+@ThreeRollPass.usable_cross_section
+def out_cross_section3(rp: ThreeRollPass, width: float) -> Polygon:
+    poly = Polygon(np.concatenate([cl.coords for cl in rp.contour_lines]))
+
+    for _ in range(3):
+        poly = clip_by_rect(poly, -math.inf, -math.inf, math.inf, width / 2)
+        poly = rotate(poly, angle=120, origin=(0, 0))
+
+    return poly

--- a/pyroll/core/roll_pass/hookimpls/profile.py
+++ b/pyroll/core/roll_pass/hookimpls/profile.py
@@ -37,10 +37,11 @@ def width(self: RollPass.OutProfile, cycle):
     if cycle:
         return None
 
-    def w(x):
-        return self.equivalent_width ** 2 / helpers.out_cross_section(self.roll_pass, x).area * self.height
+    if self.has_set("equivalent_width"):
+        def w(x):
+            return self.equivalent_width ** 2 / helpers.out_cross_section(self.roll_pass, x).area * self.height
 
-    return fixed_point(w, x0=self.width)
+        return fixed_point(w, x0=self.width)
 
 
 @RollPass.OutProfile.length
@@ -73,7 +74,6 @@ def cross_section3(self: ThreeRollPass.OutProfile) -> Polygon:
             "May be caused by critical overfilling."
         )
     return cs
-
 
 
 @RollPass.OutProfile.classifiers

--- a/pyroll/core/roll_pass/hookimpls/profile.py
+++ b/pyroll/core/roll_pass/hookimpls/profile.py
@@ -24,14 +24,9 @@ def strain(self: RollPass.OutProfile):
     return self.roll_pass.in_profile.strain + self.roll_pass.strain
 
 
-@ThreeRollPass.OutProfile.width
-def width(self: ThreeRollPass.OutProfile):
-    return 2 / 3 * np.sqrt(3) * (self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 2)
-
-
 @RollPass.OutProfile.width
 def width(self: RollPass.OutProfile):
-    return self.roll_pass.roll.groove.usable_width
+    return self.roll_pass.usable_width
 
 
 @RollPass.OutProfile.width
@@ -47,12 +42,7 @@ def length(self: RollPass.OutProfile):
 
 @RollPass.OutProfile.filling_ratio
 def filling_ratio(self: RollPass.OutProfile):
-    return self.width / self.roll_pass.roll.groove.usable_width
-
-
-@ThreeRollPass.OutProfile.filling_ratio
-def filling_ratio(self: ThreeRollPass.OutProfile):
-    return self.width / (2 / 3 * np.sqrt(3) * (self.roll_pass.roll.groove.usable_width + self.roll_pass.gap / 2))
+    return self.width / self.roll_pass.usable_width
 
 
 @RollPass.OutProfile.cross_section
@@ -73,7 +63,7 @@ def cross_section(self: RollPass.OutProfile) -> Polygon:
 
 
 @ThreeRollPass.OutProfile.cross_section
-def cross_section(self: ThreeRollPass.OutProfile) -> Polygon:
+def cross_section3(self: ThreeRollPass.OutProfile) -> Polygon:
     poly = Polygon(np.concatenate([cl.coords for cl in self.roll_pass.contour_lines]))
 
     if self.width / 2 > poly.bounds[3] * 1.01:

--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -10,6 +10,7 @@ from ...rotator import Rotator
 from ...grooves import GenericElongationGroove
 
 from ...config import Config
+from . import helpers
 
 
 @RollPass.rotation
@@ -64,41 +65,23 @@ def tip_width3(self):
 
 
 @RollPass.usable_cross_section
-def usable_cross_section(self: RollPass.OutProfile) -> Polygon:
-    width = self.usable_width
-    poly = Polygon(np.concatenate([cl.coords for cl in self.contour_lines]))
-    return clip_by_rect(poly, -width / 2, -math.inf, width / 2, math.inf)
+def usable_cross_section(self: RollPass) -> Polygon:
+    return helpers.out_cross_section(self, self.usable_width)
 
 
 @ThreeRollPass.usable_cross_section
-def usable_cross_section3(self: ThreeRollPass.OutProfile) -> Polygon:
-    width = self.usable_width
-    poly = Polygon(np.concatenate([cl.coords for cl in self.contour_lines]))
-
-    for _ in range(3):
-        poly = clip_by_rect(poly, -math.inf, -math.inf, math.inf, width / 2)
-        poly = rotate(poly, angle=120, origin=(0, 0))
-
-    return poly
+def usable_cross_section3(self: ThreeRollPass) -> Polygon:
+    return helpers.out_cross_section3(self, self.usable_width)
 
 
 @RollPass.tip_cross_section
-def tip_cross_section(self: RollPass.OutProfile) -> Polygon:
-    width = self.tip_width
-    poly = Polygon(np.concatenate([cl.coords for cl in self.contour_lines]))
-    return clip_by_rect(poly, -width / 2, -math.inf, width / 2, math.inf)
+def tip_cross_section(self: RollPass) -> Polygon:
+    return helpers.out_cross_section(self, self.tip_width)
 
 
 @ThreeRollPass.tip_cross_section
-def tip_cross_section3(self: ThreeRollPass.OutProfile) -> Polygon:
-    width = self.tip_width
-    poly = Polygon(np.concatenate([cl.coords for cl in self.contour_lines]))
-
-    for _ in range(3):
-        poly = clip_by_rect(poly, -math.inf, -math.inf, math.inf, width / 2)
-        poly = rotate(poly, angle=120, origin=(0, 0))
-
-    return poly
+def tip_cross_section3(self: ThreeRollPass) -> Polygon:
+    return helpers.out_cross_section3(self, self.tip_width)
 
 
 @RollPass.gap

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -29,8 +29,20 @@ class RollPass(DiskElementUnit, DeformationUnit):
     height = Hook[float]()
     """Maximum height of the roll pass."""
 
+    usable_width = Hook[float]()
+    """
+    Usable width (width of ideal filling).
+    Equals the usable width of the groove for two-roll passes, but deviates for three and four-roll passes.
+    """
+
     tip_width = Hook[float]()
     """Width of the intersection of the extended groove flanks (theoretical maximum filling width)."""
+
+    usable_cross_section = Hook[Polygon]()
+    """Cross-section of the roll pass at ideal filling with its usable width."""
+
+    tip_cross_section = Hook[Polygon]()
+    """Cross-section of the roll pass at filling with its tip width."""
 
     roll_force = Hook[float]()
     """Vertical roll force."""

--- a/tests/hooks/test_hook_functions.py
+++ b/tests/hooks/test_hook_functions.py
@@ -243,3 +243,23 @@ def test_tryfirst_and_trylast_inherited():
     assert Host2.hook1.functions == [
         ff22, ff12, ff2, ff1, f22, f12, f2, f1, fl22, fl12, fl2, fl1
     ]
+
+
+def test_context_manager():
+    class Host(HookHost):
+        hook1 = Hook[Any]()
+
+    host = Host()
+
+    @Host.hook1
+    def f1(self: Host):
+        return 21
+
+    def f2(self):
+        return 42
+
+    with Host.hook1(f2):
+        assert host.hook1 == 42
+
+    host.__cache__.clear()
+    assert host.hook1 == 21

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -7,7 +7,6 @@ import numpy as np
 from pyroll.core import Profile, Roll, RollPass, Transport, RoundGroove, CircularOvalGroove, PassSequence, SquareGroove
 
 
-@RollPass.Profile.flow_stress
 def flow_stress(self: RollPass.Profile):
     return 50e6 * (1 + self.strain) ** 0.2 * self.roll_pass.strain_rate ** 0.1
 
@@ -15,70 +14,72 @@ def flow_stress(self: RollPass.Profile):
 def test_solve(tmp_path: Path, caplog):
     caplog.set_level(logging.DEBUG, logger="pyroll")
 
-    in_profile = Profile.round(
-        diameter=30e-3,
-        temperature=1200 + 273.15,
-        strain=0,
-        material=["C45", "steel"],
-        length=1,
-    )
+    with RollPass.Profile.flow_stress(flow_stress):
 
-    sequence = PassSequence([
-        RollPass(
-            label="Oval I",
-            roll=Roll(
-                groove=CircularOvalGroove(
-                    depth=8e-3,
-                    r1=6e-3,
-                    r2=40e-3
-                ),
-                nominal_radius=160e-3,
-                rotational_frequency=1,
-                neutral_point=-20e-3
-            ),
-            gap=2e-3,
-        ),
-        Transport(
-            label="I => II",
-            duration=1
-        ),
-        RollPass(
-            label="Round II",
-            roll=Roll(
-                groove=RoundGroove(
-                    r1=1e-3,
-                    r2=12.5e-3,
-                    depth=11.5e-3
-                ),
-                nominal_radius=160e-3,
-                rotational_frequency=1
-            ),
-            gap=2e-3,
-        ),
-        Transport(
-            label="II => III",
-            duration=1
-        ),
-        RollPass(
-            label="Oval III",
-            roll=Roll(
-                groove=CircularOvalGroove(
-                    depth=6e-3,
-                    r1=6e-3,
-                    r2=35e-3
-                ),
-                nominal_radius=160e-3,
-                rotational_frequency=1
-            ),
-            gap=2e-3,
-        ),
-    ])
+        in_profile = Profile.round(
+            diameter=30e-3,
+            temperature=1200 + 273.15,
+            strain=0,
+            material=["C45", "steel"],
+            length=1,
+        )
 
-    try:
-        sequence.solve(in_profile)
-    finally:
-        print("\nLog:")
-        print(caplog.text)
+        sequence = PassSequence([
+            RollPass(
+                label="Oval I",
+                roll=Roll(
+                    groove=CircularOvalGroove(
+                        depth=8e-3,
+                        r1=6e-3,
+                        r2=40e-3
+                    ),
+                    nominal_radius=160e-3,
+                    rotational_frequency=1,
+                    neutral_point=-20e-3
+                ),
+                gap=2e-3,
+            ),
+            Transport(
+                label="I => II",
+                duration=1
+            ),
+            RollPass(
+                label="Round II",
+                roll=Roll(
+                    groove=RoundGroove(
+                        r1=1e-3,
+                        r2=12.5e-3,
+                        depth=11.5e-3
+                    ),
+                    nominal_radius=160e-3,
+                    rotational_frequency=1
+                ),
+                gap=2e-3,
+            ),
+            Transport(
+                label="II => III",
+                duration=1
+            ),
+            RollPass(
+                label="Oval III",
+                roll=Roll(
+                    groove=CircularOvalGroove(
+                        depth=6e-3,
+                        r1=6e-3,
+                        r2=35e-3
+                    ),
+                    nominal_radius=160e-3,
+                    rotational_frequency=1
+                ),
+                gap=2e-3,
+            ),
+        ])
+
+        try:
+            sequence.solve(in_profile)
+        finally:
+            print("\nLog:")
+            print(caplog.text)
 
     try:
         import pyroll.report

--- a/tests/test_solve_spreading.py
+++ b/tests/test_solve_spreading.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from pyroll.core import Profile, Roll, RollPass, Transport, RoundGroove, CircularOvalGroove, PassSequence,\
+from pyroll.core import Profile, Roll, RollPass, Transport, RoundGroove, CircularOvalGroove, PassSequence, \
     root_hooks, Rotator
 
 
@@ -18,80 +18,79 @@ def equivalent_width(self: RollPass.OutProfile, cycle):
 def test_solve(tmp_path: Path, caplog):
     caplog.set_level(logging.INFO, logger="pyroll")
 
-    equivalent_width_hf = RollPass.OutProfile.equivalent_width.add_function(equivalent_width)
+    with RollPass.OutProfile.equivalent_width(equivalent_width):
 
-    root_hooks.add(RollPass.OutProfile.equivalent_width)
-    root_hooks.add(Rotator.OutProfile.equivalent_width)
+        root_hooks.add(RollPass.OutProfile.equivalent_width)
+        root_hooks.add(Rotator.OutProfile.equivalent_width)
 
-    in_profile = Profile.round(
-        diameter=30e-3,
-        temperature=1200 + 273.15,
-        strain=0,
-        material=["C45", "steel"],
-        length=1,
-        flow_stress=100e6,
-    )
+        in_profile = Profile.round(
+            diameter=30e-3,
+            temperature=1200 + 273.15,
+            strain=0,
+            material=["C45", "steel"],
+            length=1,
+            flow_stress=100e6,
+        )
 
-    sequence = PassSequence([
-        RollPass(
-            label="Oval I",
-            roll=Roll(
-                groove=CircularOvalGroove(
-                    depth=8e-3,
-                    r1=6e-3,
-                    r2=40e-3
+        sequence = PassSequence([
+            RollPass(
+                label="Oval I",
+                roll=Roll(
+                    groove=CircularOvalGroove(
+                        depth=8e-3,
+                        r1=6e-3,
+                        r2=40e-3
+                    ),
+                    nominal_radius=160e-3,
+                    rotational_frequency=1,
+                    neutral_point=-20e-3
                 ),
-                nominal_radius=160e-3,
-                rotational_frequency=1,
-                neutral_point=-20e-3
+                gap=2e-3,
             ),
-            gap=2e-3,
-        ),
-        Transport(
-            label="I => II",
-            duration=1
-        ),
-        RollPass(
-            label="Round II",
-            roll=Roll(
-                groove=RoundGroove(
-                    r1=1e-3,
-                    r2=12.5e-3,
-                    depth=11.5e-3
+            Transport(
+                label="I => II",
+                duration=1
+            ),
+            RollPass(
+                label="Round II",
+                roll=Roll(
+                    groove=RoundGroove(
+                        r1=1e-3,
+                        r2=12.5e-3,
+                        depth=11.5e-3
+                    ),
+                    nominal_radius=160e-3,
+                    rotational_frequency=1
                 ),
-                nominal_radius=160e-3,
-                rotational_frequency=1
+                gap=2e-3,
             ),
-            gap=2e-3,
-        ),
-        Transport(
-            label="II => III",
-            duration=1
-        ),
-        RollPass(
-            label="Oval III",
-            roll=Roll(
-                groove=CircularOvalGroove(
-                    depth=6e-3,
-                    r1=6e-3,
-                    r2=35e-3
+            Transport(
+                label="II => III",
+                duration=1
+            ),
+            RollPass(
+                label="Oval III",
+                roll=Roll(
+                    groove=CircularOvalGroove(
+                        depth=6e-3,
+                        r1=6e-3,
+                        r2=35e-3
+                    ),
+                    nominal_radius=160e-3,
+                    rotational_frequency=1
                 ),
-                nominal_radius=160e-3,
-                rotational_frequency=1
+                gap=2e-3,
             ),
-            gap=2e-3,
-        ),
-    ])
+        ])
 
-    try:
-        sequence.solve(in_profile)
-    finally:
-        print("\nLog:")
-        print(caplog.text)
+        try:
+            sequence.solve(in_profile)
+        finally:
+            print("\nLog:")
+            print(caplog.text)
 
-        RollPass.OutProfile.equivalent_width.remove_function(equivalent_width_hf)
-        root_hooks.remove(RollPass.OutProfile.equivalent_width)
-        root_hooks.remove(Rotator.OutProfile.equivalent_width)
+            root_hooks.remove(RollPass.OutProfile.equivalent_width)
+            root_hooks.remove(Rotator.OutProfile.equivalent_width)
 
     try:
         import pyroll.report

--- a/tests/test_solve_spreading.py
+++ b/tests/test_solve_spreading.py
@@ -1,0 +1,109 @@
+import logging
+import webbrowser
+from pathlib import Path
+
+import numpy as np
+
+from pyroll.core import Profile, Roll, RollPass, Transport, RoundGroove, CircularOvalGroove, PassSequence,\
+    root_hooks, Rotator
+
+
+def equivalent_width(self: RollPass.OutProfile, cycle):
+    if cycle:
+        return None
+
+    return self.roll_pass.in_profile.equivalent_width * self.roll_pass.draught ** -0.5
+
+
+def test_solve(tmp_path: Path, caplog):
+    caplog.set_level(logging.INFO, logger="pyroll")
+
+    equivalent_width_hf = RollPass.OutProfile.equivalent_width.add_function(equivalent_width)
+
+    root_hooks.add(RollPass.OutProfile.equivalent_width)
+    root_hooks.add(Rotator.OutProfile.equivalent_width)
+
+    in_profile = Profile.round(
+        diameter=30e-3,
+        temperature=1200 + 273.15,
+        strain=0,
+        material=["C45", "steel"],
+        length=1,
+        flow_stress=100e6,
+    )
+
+    sequence = PassSequence([
+        RollPass(
+            label="Oval I",
+            roll=Roll(
+                groove=CircularOvalGroove(
+                    depth=8e-3,
+                    r1=6e-3,
+                    r2=40e-3
+                ),
+                nominal_radius=160e-3,
+                rotational_frequency=1,
+                neutral_point=-20e-3
+            ),
+            gap=2e-3,
+        ),
+        Transport(
+            label="I => II",
+            duration=1
+        ),
+        RollPass(
+            label="Round II",
+            roll=Roll(
+                groove=RoundGroove(
+                    r1=1e-3,
+                    r2=12.5e-3,
+                    depth=11.5e-3
+                ),
+                nominal_radius=160e-3,
+                rotational_frequency=1
+            ),
+            gap=2e-3,
+        ),
+        Transport(
+            label="II => III",
+            duration=1
+        ),
+        RollPass(
+            label="Oval III",
+            roll=Roll(
+                groove=CircularOvalGroove(
+                    depth=6e-3,
+                    r1=6e-3,
+                    r2=35e-3
+                ),
+                nominal_radius=160e-3,
+                rotational_frequency=1
+            ),
+            gap=2e-3,
+        ),
+    ])
+
+    try:
+        sequence.solve(in_profile)
+    finally:
+        print("\nLog:")
+        print(caplog.text)
+
+        RollPass.OutProfile.equivalent_width.remove_function(equivalent_width_hf)
+        root_hooks.remove(RollPass.OutProfile.equivalent_width)
+        root_hooks.remove(Rotator.OutProfile.equivalent_width)
+
+    try:
+        import pyroll.report
+
+        report = pyroll.report.report(sequence)
+
+        report_file = tmp_path / "report.html"
+        report_file.write_text(report)
+        print(report_file)
+        webbrowser.open(report_file.as_uri())
+
+    except ImportError:
+        pass
+
+    assert not np.isclose(sequence[0].out_profile.filling_ratio, 1)


### PR DESCRIPTION
Unfortunately, right after publication of 2.0.0 errors occurred while publishing plugins.

- Spreading using equivalent width reversal did not work.
- Heavily overfilled grooves without spreading model.

Reason was the no longer cleared, but reevaluated, cache since 8ca461b.
Fixed with this PR alongside with some related refactorings.