### PR TITLE
Fix ConfigValues

### DIFF
--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -7,8 +7,14 @@ class ConfigValue:
     """Helper descriptor for storing configuration values, able to determine the value from explictly set values,
      environment variables and default values."""
 
-    def __init__(self, default, env_var: Optional[str] = None, env_var_prefix: Optional[str] = None,
-                 parser: Optional[Callable[[str], Any]] = None):
+    def __init__(
+            self,
+            default,
+            *,
+            env_var: Optional[str] = None,
+            env_var_prefix: Optional[str] = None,
+            parser: Optional[Callable[[str], Any]] = None
+    ):
         self.default = default
         self.type = type(default)
         self.parser = parser

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -31,6 +31,9 @@ class ConfigValue:
         return f"{self._env_var_prefix}_{self.name.upper()}"
 
     def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
         value = getattr(instance, "_" + self.name, None)
 
         if value is not None:
@@ -127,7 +130,13 @@ def config(env_var_prefix):
                 if not isinstance(v, ConfigValue):
                     meta_dict[n] = ConfigValue(default=v, env_var_prefix=env_var_prefix)
                 else:
-                    meta_dict[n] = ConfigValue(default=v.default, env_var_prefix=env_var_prefix)
+                    # noinspection PyProtectedMember
+                    meta_dict[n] = ConfigValue(
+                        default=v.default,
+                        env_var_prefix=env_var_prefix,
+                        env_var=v._env_var,
+                        parser=v.parser
+                    )
 
         meta = type(cls.__name__ + "Meta", (ConfigMeta,), meta_dict)
         cls = meta(cls.__name__, cls.__bases__, cls_dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ class Config:
     VAR_STR = "abc"
     VAR_DICT = {}
     PARSED = ConfigValue(CustomData(42), parser=lambda v: CustomData(int(v)))
+    SPEC_ENV = ConfigValue(42, env_var="P_SPEC_ENV")
 
 
 def test_config_default():
@@ -108,5 +109,12 @@ def test_parser(monkeypatch):
     assert Config.PARSED.value == 42
     monkeypatch.setenv("PYROLL_TEST_PARSED", "21")
     assert Config.PARSED.value == 21
+
+
+def test_env_var_override(monkeypatch):
+    assert type(Config).SPEC_ENV.env_var == "P_SPEC_ENV"
+    monkeypatch.setenv("P_SPEC_ENV", "21")
+    assert Config.SPEC_ENV == 21
+
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,12 @@
 import os
 
 from pyroll.core import config
+from pyroll.core.config import ConfigValue
+
+
+class CustomData:
+    def __init__(self, value: int):
+        self.value = value
 
 
 @config("PYROLL_TEST")
@@ -16,6 +22,7 @@ class Config:
     VAR_TUPLE = ("a", "b")
     VAR_STR = "abc"
     VAR_DICT = {}
+    PARSED = ConfigValue(CustomData(42), parser=lambda v: CustomData(int(v)))
 
 
 def test_config_default():
@@ -71,7 +78,7 @@ def test_config_explicit():
 
 
 def test_config_env_and_explicit(monkeypatch):
-    monkeypatch.setenv("PYROLL_TEST_PYROLL_TEST_VAR", "21")
+    monkeypatch.setenv("PYROLL_TEST_VAR", "21")
     Config.VAR = 42
 
     assert Config.VAR == 42
@@ -88,3 +95,18 @@ def test_config_del():
     assert Config.VAR == 42
     del Config.VAR
     assert Config.VAR == 1
+
+
+def test_config_meta():
+    meta = type(Config)
+    assert meta.__name__ == "ConfigMeta"
+
+    assert isinstance(meta.VAR, ConfigValue)
+
+
+def test_parser(monkeypatch):
+    assert Config.PARSED.value == 42
+    monkeypatch.setenv("PYROLL_TEST_PARSED", "21")
+    assert Config.PARSED.value == 21
+
+


### PR DESCRIPTION
During development of the CLI an error in the config processor appeared. The descriptors did not return themselves if no instance was given.

Also, the parser was not yielded to the new `ConfigValue` instance by the `config` decorator.