### PR TITLE
Add default duration = 0 to Rotator

### DIFF
--- a/pyroll/core/rotator/hookimpls.py
+++ b/pyroll/core/rotator/hookimpls.py
@@ -2,6 +2,11 @@ from .rotator import Rotator
 from shapely.affinity import rotate
 
 
+@Rotator.duration
+def duration(self: Rotator):
+    return 0
+
+
 @Rotator.OutProfile.cross_section
 def rotated_cross_section(self: Rotator.OutProfile):
     return rotate(self.rotator.in_profile.cross_section, angle=self.rotator.rotation, origin=(0, 0))


### PR DESCRIPTION
Due to non-intuitive behavior when using dedicated `Rotator`. 