### PR TITLE
Hook Wrappers

### DIFF
--- a/pyroll/core/hooks.py
+++ b/pyroll/core/hooks.py
@@ -273,7 +273,15 @@ class Hook(Generic[T]):
 
         :return: the underlying function object
         """
-        self._functions.remove(func)
+        for store in [
+            self._functions,
+            self._last_functions,
+            self._first_functions,
+        ]:
+            try:
+                store.remove(func)
+            except ValueError:
+                continue
         return func.function
 
     def __repr__(self):


### PR DESCRIPTION
Implement hook wrapper functions (inspired by [pluggy](https://pluggy.readthedocs.io/en/stable/#wrappers)).

They take precedence over all other hook functions and allow to modify hook function results stemming from other places. They work as normal hook functions with `trylast` and `tryfirst`.

They must contain exactly one `yield` expression, the argument of `yield`, however, is ignored. It is just used to inject the lower level result value.
Use a `return` statement to return the modified result. See the tests for examples.

Pay attention on:
- The value of `(yield)` may be `None`, if no hook function at lower level returns a value. No exception is raised in this case by the framework, check yourself for `None` and react accordingly.
- The wrapper is called in cycle at `yield`, you have to skip manually using the `cycle` argument in the wrapper body as shown in the tests. The wrapper is not automatically skipped to allow maximum flexibility.

There may be used multiple hook wrappers together in onion shell style.