### PR TITLE
impl Unit.prev_of and Unit.next_of methods

### DIFF
--- a/pyroll/core/rotator/rotator.py
+++ b/pyroll/core/rotator/rotator.py
@@ -22,14 +22,9 @@ class Rotator(Unit):
         from ..roll_pass import RollPass
 
         if isinstance(self.parent, RollPass):
-            prev = self.parent.prev
-        else:
-            prev = self.prev
+            return self.parent.prev_of(RollPass)
 
-        while True:
-            if isinstance(prev, RollPass):
-                return prev
-            prev = prev.prev
+        return self.prev_of(RollPass)
 
     @property
     def next_roll_pass(self):
@@ -44,11 +39,7 @@ class Rotator(Unit):
         if isinstance(self.parent, RollPass):
             return self.parent
 
-        next_ = self.next
-        while True:
-            if isinstance(next_, RollPass):
-                return next_
-            next_ = next_.next
+        return self.next_of(RollPass)
 
     class Profile(Unit.Profile):
         """Represents a profile in context of a rotator."""

--- a/pyroll/core/unit/unit.py
+++ b/pyroll/core/unit/unit.py
@@ -71,6 +71,20 @@ class Unit(HookHost):
             raise IndexError("This unit has no previous, as it is the first one.")
         return self.parent.subunits[i - 1]
 
+    def prev_of(self, unit_type: type):
+        """
+        Returns the instance of the first predecessor of the given type in the sequence.
+        Like the :py:attr:`Unit.prev` property, but returns the first unit with given type.
+
+        :raises ValueError: if this unit has no parent unit
+        """
+        prev = self.prev
+
+        while True:
+            if isinstance(prev, unit_type):
+                return prev
+            prev = prev.prev
+
     @property
     def next(self):
         """
@@ -84,6 +98,20 @@ class Unit(HookHost):
         if i == len(self.parent.subunits) - 1:
             raise IndexError("This unit has no next, as it is the last one.")
         return self.parent.subunits[i + 1]
+
+    def next_of(self, unit_type: type):
+        """
+        Returns the instance of the first predecessor of the given type in the sequence.
+        Like the :py:attr:`Unit.prev` property, but returns the first unit with given type.
+
+        :raises ValueError: if this unit has no parent unit
+        """
+        next_ = self.next
+
+        while True:
+            if isinstance(next_, unit_type):
+                return next_
+            next_ = next_.next
 
     def init_solve(self, in_profile: BaseProfile):
         """


### PR DESCRIPTION
Implementations acc. to the request in #67.
Two new methods in `Unit` which return the previous resp. next unit of a given type in the sequence.
Updated the existing methods in `Rotator` to make use of them. 