### PR TITLE
Add fallback of transport velocity getting from prev unit velocity

### DIFF
--- a/pyroll/core/transport/hookimpls.py
+++ b/pyroll/core/transport/hookimpls.py
@@ -9,7 +9,16 @@ def out_strain(self: Transport.OutProfile):
 
 @Transport.duration
 def duration(self: Transport):
-    return self.length / self.velocity
+    if self.has_set_or_cached("length"):
+        return self.length / self.velocity
+
+
+@Transport.velocity(
+    trylast=True  # do not override getting from in_profile
+)
+def conti_velocity(self: Transport):
+    if self.has_set_or_cached("length"):  # probably indicates conti process
+        return self.prev.velocity
 
 
 @Transport.environment_temperature


### PR DESCRIPTION
Due to question raised by K. van Putten.
Enables giving length in transports without specifying explicitly the velocity in conti processes.