### PR TITLE
Add Explicit Hook Functions

### DIFF
--- a/pyroll/core/hooks.py
+++ b/pyroll/core/hooks.py
@@ -167,6 +167,18 @@ class Hook(Generic[T]):
         # try to get value explicitly set by user
         result = instance.__dict__.get(self.name, None)
         if result is not None:
+            if callable(result):
+                if len(inspect.signature(result).parameters) == 0:
+                    result = result()
+                else:
+                    result = result(instance)
+
+                self.owner.logger.debug(
+                    f"Hook %s.%s on %s: resolved with explicit function result value %s.",
+                    self.owner.__qualname__, self.name, instance, result
+                )
+                return result
+
             self.owner.logger.debug(
                 f"Hook %s.%s on %s: resolved with explicit value %s.",
                 self.owner.__qualname__, self.name, instance, result

--- a/tests/hooks/test_hook_functions.py
+++ b/tests/hooks/test_hook_functions.py
@@ -320,3 +320,20 @@ def test_wrapper_none():
 
     host = Host()
     assert host.hook1
+
+
+def test_explicit_function():
+    class Host(HookHost):
+        hook1 = Hook[Any]()
+
+    @Host.hook1
+    def f1(self: Host, cycle):
+        return 42
+
+    host = Host()
+
+    host.hook1 = lambda self: 21
+    assert host.hook1 == 21
+
+    host.hook1 = lambda: 21
+    assert host.hook1 == 21


### PR DESCRIPTION
To allow giving lambda functions as explicit hook value.
Only on explicit hook values callability will be checked. 
Allowed are parameterless functions and functions with one parameter (`self`).
So for example:

```python
Profile.round(
    diameter=10e-3,
    density=lambda self: 7.85 / (1 + 3 * 1e-5 * self.temperature),
)
```