### PR TITLE
Add Plot Methods for Certain Objects

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pytest ~= 7.0",
     "matplotlib ~= 3.6",
     "pyroll-report ~= 2.0.0",
+    "jupyter"
 ]
 
 [envs.test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dependencies = [
 
 dynamic = ["version"]
 
+[project.optional-dependencies]
+plot = [
+    "matplotlib ~= 3.7"
+]
+
 [project.urls]
 Homepage = "https://pyroll-project.github.io"
 Repository = "https://github.com/pyroll-project/pyroll-core"

--- a/pyroll/core/grooves/base.py
+++ b/pyroll/core/grooves/base.py
@@ -57,3 +57,38 @@ class GrooveBase(ABC):
 
     def __str__(self):
         return f"{type(self).__name__} {self.usable_width:.4g} x {self.depth:.4g} ({', '.join(self.classifiers)})"
+
+    try:
+        import matplotlib.pyplot as plt
+
+        def plot(self, **kwargs) -> plt.Figure:
+            """
+            Returns a matplotlib figure visualizing this instance.
+            :param kwargs: keyword arguments passed to the figure constructor
+
+            :raises NotImplementedError: if matplotlib is not importable
+            """
+
+            import matplotlib.pyplot as plt
+
+            fig: plt.Figure = plt.figure(**kwargs)
+            ax: plt.Axes = fig.subplots()
+
+            ax.set_ylabel("y")
+            ax.set_xlabel("z")
+
+            ax.set_aspect("equal", "datalim")
+            ax.grid(lw=0.5)
+
+            ax.plot(*self.contour_line.xy, color="k")
+            return fig
+
+    except ImportError:
+        def plot(self, **kwargs) -> 'plt.Figure':
+            """
+            Returns a matplotlib figure visualizing this instance.
+            :param kwargs: keyword arguments passed to the figure constructor
+
+            :raises NotImplementedError: if matplotlib is not importable
+            """
+            raise NotImplementedError("This method is only available if matplotlib is installed in the environment.")

--- a/pyroll/core/grooves/base.py
+++ b/pyroll/core/grooves/base.py
@@ -4,8 +4,10 @@ from typing import Union, Tuple
 import numpy as np
 from shapely.geometry import Polygon, LineString
 
+from ..repr import ReprMixin
 
-class GrooveBase(ABC):
+
+class GrooveBase(ReprMixin):
     """Abstract base class for all grooves."""
 
     @property
@@ -55,40 +57,30 @@ class GrooveBase(ABC):
         """Function of the local groove depth in dependence on the z-coordinate."""
         raise NotImplemented
 
-    def __str__(self):
-        return f"{type(self).__name__} {self.usable_width:.4g} x {self.depth:.4g} ({', '.join(self.classifiers)})"
+    @property
+    def __attrs__(self):
+        return {
+            n: v for n in ["depth", "usable_width", "classifiers", "contour_line"]
+            if (v := getattr(self, n))
+        }
 
-    try:
-        import matplotlib.pyplot as plt
-
-        def plot(self, **kwargs) -> plt.Figure:
-            """
-            Returns a matplotlib figure visualizing this instance.
-            :param kwargs: keyword arguments passed to the figure constructor
-
-            :raises NotImplementedError: if matplotlib is not importable
-            """
-
+    def plot(self, **kwargs):
+        try:
             import matplotlib.pyplot as plt
+        except ImportError as e:
+            raise RuntimeError(
+                "This method is only available if matplotlib is installed in the environment. "
+                "You may install it using the 'plot' extra of pyroll-core."
+            ) from e
 
-            fig: plt.Figure = plt.figure(**kwargs)
-            ax: plt.Axes = fig.subplots()
+        fig: plt.Figure = plt.figure(**kwargs)
+        ax: plt.Axes = fig.subplots()
 
-            ax.set_ylabel("y")
-            ax.set_xlabel("z")
+        ax.set_ylabel("y")
+        ax.set_xlabel("z")
 
-            ax.set_aspect("equal", "datalim")
-            ax.grid(lw=0.5)
+        ax.set_aspect("equal", "datalim")
+        ax.grid(lw=0.5)
 
-            ax.plot(*self.contour_line.xy, color="k")
-            return fig
-
-    except ImportError:
-        def plot(self, **kwargs) -> 'plt.Figure':
-            """
-            Returns a matplotlib figure visualizing this instance.
-            :param kwargs: keyword arguments passed to the figure constructor
-
-            :raises NotImplementedError: if matplotlib is not importable
-            """
-            raise NotImplementedError("This method is only available if matplotlib is installed in the environment.")
+        ax.plot(*self.contour_line.xy, color="k")
+        return fig

--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -413,38 +413,24 @@ class Profile(HookHost):
             except TypeError:
                 raise ValueError("Value of self.material is neither a string or a collection of strings.")
 
-    try:
-        import matplotlib.pyplot as plt
-
-        def plot(self, **kwargs) -> plt.Figure:
-            """
-            Returns a matplotlib figure visualizing this instance.
-            :param kwargs: keyword arguments passed to the figure constructor
-
-            :raises NotImplementedError: if matplotlib is not importable
-            """
-
+    def plot(self, **kwargs):
+        try:
             import matplotlib.pyplot as plt
+        except ImportError as e:
+            raise RuntimeError(
+                "This method is only available if matplotlib is installed in the environment. "
+                "You may install it using the 'plot' extra of pyroll-core."
+            ) from e
 
-            fig: plt.Figure = plt.figure(**kwargs)
-            ax: plt.Axes = fig.subplots()
+        fig: plt.Figure = plt.figure(**kwargs)
+        ax: plt.Axes = fig.subplots()
 
-            ax.set_ylabel("y")
-            ax.set_xlabel("z")
+        ax.set_ylabel("y")
+        ax.set_xlabel("z")
 
-            ax.set_aspect("equal", "datalim")
-            ax.grid(lw=0.5)
+        ax.set_aspect("equal", "datalim")
+        ax.grid(lw=0.5)
 
-            ax.plot(*self.cross_section.boundary.xy, color="k")
-            ax.fill(*self.cross_section.boundary.xy, color="k", alpha=0.5)
-            return fig
-
-    except ImportError:
-        def plot(self, **kwargs) -> 'plt.Figure':
-            """
-            Returns a matplotlib figure visualizing this instance.
-            :param kwargs: keyword arguments passed to the figure constructor
-
-            :raises NotImplementedError: if matplotlib is not importable
-            """
-            raise NotImplementedError("This method is only available if matplotlib is installed in the environment.")
+        ax.plot(*self.cross_section.boundary.xy, color="k")
+        ax.fill(*self.cross_section.boundary.xy, color="k", alpha=0.5)
+        return fig

--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -412,3 +412,36 @@ class Profile(HookHost):
                 }
             except TypeError:
                 raise ValueError("Value of self.material is neither a string or a collection of strings.")
+
+    try:
+        import matplotlib.pyplot as plt
+
+        def plot(self) -> plt.Figure:
+            """
+            Returns a matplotlib figure visualizing this instance.
+
+            :raises NotImplementedError: if matplotlib is not importable
+            """
+
+            import matplotlib.pyplot as plt
+
+            fig: plt.Figure = plt.figure(constrained_layout=True, figsize=(4, 4))
+            ax: plt.Axes = fig.subplots()
+
+            ax.set_ylabel("y")
+            ax.set_xlabel("z")
+
+            ax.set_aspect("equal", "datalim")
+            ax.grid(lw=0.5)
+
+            ax.fill(*self.cross_section.boundary.xy, alpha=0.5, label="in profile")
+            return fig
+
+    except ImportError:
+        def plot(self) -> 'plt.Figure':
+            """
+            Returns a matplotlib figure visualizing this instance.
+
+            :raises NotImplementedError: if matplotlib is not importable
+            """
+            raise NotImplementedError("This method is only available if matplotlib is installed in the environment.")

--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -416,16 +416,17 @@ class Profile(HookHost):
     try:
         import matplotlib.pyplot as plt
 
-        def plot(self) -> plt.Figure:
+        def plot(self, **kwargs) -> plt.Figure:
             """
             Returns a matplotlib figure visualizing this instance.
+            :param kwargs: keyword arguments passed to the figure constructor
 
             :raises NotImplementedError: if matplotlib is not importable
             """
 
             import matplotlib.pyplot as plt
 
-            fig: plt.Figure = plt.figure(constrained_layout=True, figsize=(4, 4))
+            fig: plt.Figure = plt.figure(**kwargs)
             ax: plt.Axes = fig.subplots()
 
             ax.set_ylabel("y")
@@ -434,13 +435,15 @@ class Profile(HookHost):
             ax.set_aspect("equal", "datalim")
             ax.grid(lw=0.5)
 
-            ax.fill(*self.cross_section.boundary.xy, alpha=0.5, label="in profile")
+            ax.plot(*self.cross_section.boundary.xy, color="k")
+            ax.fill(*self.cross_section.boundary.xy, color="k", alpha=0.5)
             return fig
 
     except ImportError:
-        def plot(self) -> 'plt.Figure':
+        def plot(self, **kwargs) -> 'plt.Figure':
             """
             Returns a matplotlib figure visualizing this instance.
+            :param kwargs: keyword arguments passed to the figure constructor
 
             :raises NotImplementedError: if matplotlib is not importable
             """

--- a/pyroll/core/repr.py
+++ b/pyroll/core/repr.py
@@ -15,11 +15,13 @@ class ReprMixin(ABC):
     def plot(self, **kwargs):
         """
         Returns a matplotlib figure visualizing this instance.
+        It is not required to implement this method.
         :param kwargs: keyword arguments passed to the figure constructor
 
-        :raises NotImplementedError: if matplotlib is not importable or the current instance supports no plotting
+        :raises RuntimeError: if matplotlib is not importable
+        :raises TypeError: if the current type does not support plotting
         """
-        raise NotImplementedError()
+        raise TypeError("This type does not support plotting.")
 
     def __str__(self):
         return type(self).__qualname__

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -189,63 +189,50 @@ class RollPass(DiskElementUnit, DeformationUnit):
         class OutProfile(Profile, DiskElementUnit.DiskElement.OutProfile, DeformationUnit.OutProfile):
             """Represents an outgoing profile of a disk element unit."""
 
-    try:
-        import matplotlib.pyplot as plt
-
-        def plot(self, **kwargs) -> plt.Figure:
-            """
-            Returns a matplotlib figure visualizing this instance.
-            :param kwargs: keyword arguments passed to the figure constructor
-
-            :raises NotImplementedError: if matplotlib is not importable
-            """
-
+    def plot(self, **kwargs):
+        try:
             import matplotlib.pyplot as plt
+        except ImportError as e:
+            raise RuntimeError(
+                "This method is only available if matplotlib is installed in the environment. "
+                "You may install it using the 'plot' extra of pyroll-core."
+            ) from e
 
-            fig: plt.Figure = plt.figure(**kwargs)
-            ax: plt.Axes
-            axl: plt.Axes
-            ax, axl = fig.subplots(nrows=2, height_ratios=[1, 0.3])
+        fig: plt.Figure = plt.figure(**kwargs)
+        ax: plt.Axes
+        axl: plt.Axes
+        ax, axl = fig.subplots(nrows=2, height_ratios=[1, 0.3])
 
-            if self.label:
-                ax.set_title(f"Roll Pass '{self.label}'")
+        if self.label:
+            ax.set_title(f"Roll Pass '{self.label}'")
 
-            ax.set_ylabel("y")
-            ax.set_xlabel("z")
+        ax.set_ylabel("y")
+        ax.set_xlabel("z")
 
-            ax.set_aspect("equal", "datalim")
-            ax.grid(lw=0.5)
+        ax.set_aspect("equal", "datalim")
+        ax.grid(lw=0.5)
 
-            c = []
-            ipp = []
-            ipr = []
-            opp = []
-            opr = []
+        c = []
+        ipp = []
+        ipr = []
+        opp = []
+        opr = []
 
-            for cl in self.contour_lines:
-                c = ax.plot(*cl.xy, color="k", label="roll surface")
+        for cl in self.contour_lines:
+            c = ax.plot(*cl.xy, color="k", label="roll surface")
 
-            if self.in_profile:
-                ipp = ax.fill(*self.in_profile.cross_section.boundary.xy, alpha=0.5, color="red", label="in profile")
-                ipr = ax.fill(*self.in_profile.equivalent_rectangle.boundary.xy, fill=False, color="red", ls="--",
-                              label="in eq. rectangle")
+        if self.in_profile:
+            ipp = ax.fill(*self.in_profile.cross_section.boundary.xy, alpha=0.5, color="red", label="in profile")
+            ipr = ax.fill(*self.in_profile.equivalent_rectangle.boundary.xy, fill=False, color="red", ls="--",
+                          label="in eq. rectangle")
 
-            if self.out_profile:
-                opp = ax.fill(*self.out_profile.cross_section.boundary.xy, alpha=0.5, color="blue", label="out profile")
-                opr = ax.fill(*self.out_profile.equivalent_rectangle.boundary.xy, fill=False, color="blue", ls="--",
-                              label="out eq. rectangle")
+        if self.out_profile:
+            opp = ax.fill(*self.out_profile.cross_section.boundary.xy, alpha=0.5, color="blue", label="out profile")
+            opr = ax.fill(*self.out_profile.equivalent_rectangle.boundary.xy, fill=False, color="blue", ls="--",
+                          label="out eq. rectangle")
 
-            axl.axis("off")
-            axl.legend(handles=c + ipp + opp + ipr + opr, ncols=2, loc="lower center")
-            fig.set_layout_engine('constrained')
+        axl.axis("off")
+        axl.legend(handles=c + ipp + opp + ipr + opr, ncols=2, loc="lower center")
+        fig.set_layout_engine('constrained')
 
-            return fig
-
-    except ImportError:
-        def plot(self, **kwargs) -> 'plt.Figure':
-            """
-            Returns a matplotlib figure visualizing this instance.
-
-            :raises NotImplementedError: if matplotlib is not importable
-            """
-            raise NotImplementedError("This method is only available if matplotlib is installed in the environment.")
+        return fig

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -188,3 +188,63 @@ class RollPass(DiskElementUnit, DeformationUnit):
 
         class OutProfile(Profile, DiskElementUnit.DiskElement.OutProfile, DeformationUnit.OutProfile):
             """Represents an outgoing profile of a disk element unit."""
+
+    try:
+        import matplotlib.pyplot as plt
+
+        def plot(self) -> plt.Figure:
+            """
+            Returns a matplotlib figure visualizing this instance.
+
+            :raises NotImplementedError: if matplotlib is not importable
+            """
+
+            import matplotlib.pyplot as plt
+
+            fig: plt.Figure = plt.figure(constrained_layout=True, figsize=(6, 4))
+            ax: plt.Axes
+            axl: plt.Axes
+            ax, axl = fig.subplots(nrows=2, height_ratios=[1, 0.3])
+
+            if self.label:
+                ax.set_title(f"Roll Pass '{self.label}'")
+
+            ax.set_ylabel("y")
+            ax.set_xlabel("z")
+
+            ax.set_aspect("equal", "datalim")
+            ax.grid(lw=0.5)
+
+            c = []
+            ipp = []
+            ipr = []
+            opp = []
+            opr = []
+
+            for cl in self.contour_lines:
+                c = ax.plot(*cl.xy, color="k", label="roll surface")
+
+            if self.in_profile:
+                ipp = ax.fill(*self.in_profile.cross_section.boundary.xy, alpha=0.5, color="red", label="in profile")
+                ipr = ax.fill(*self.in_profile.equivalent_rectangle.boundary.xy, fill=False, color="red", ls="--",
+                              label="in eq. rectangle")
+
+            if self.out_profile:
+                opp = ax.fill(*self.out_profile.cross_section.boundary.xy, alpha=0.5, color="blue", label="out profile")
+                opr = ax.fill(*self.out_profile.equivalent_rectangle.boundary.xy, fill=False, color="blue", ls="--",
+                              label="out eq. rectangle")
+
+            axl.axis("off")
+            axl.legend(handles=c + ipp + opp + ipr + opr, ncols=2, loc="lower center")
+            fig.set_layout_engine('constrained')
+
+            return fig
+
+    except ImportError:
+        def plot(self) -> 'plt.Figure':
+            """
+            Returns a matplotlib figure visualizing this instance.
+
+            :raises NotImplementedError: if matplotlib is not importable
+            """
+            raise NotImplementedError("This method is only available if matplotlib is installed in the environment.")

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -192,16 +192,17 @@ class RollPass(DiskElementUnit, DeformationUnit):
     try:
         import matplotlib.pyplot as plt
 
-        def plot(self) -> plt.Figure:
+        def plot(self, **kwargs) -> plt.Figure:
             """
             Returns a matplotlib figure visualizing this instance.
+            :param kwargs: keyword arguments passed to the figure constructor
 
             :raises NotImplementedError: if matplotlib is not importable
             """
 
             import matplotlib.pyplot as plt
 
-            fig: plt.Figure = plt.figure(constrained_layout=True, figsize=(6, 4))
+            fig: plt.Figure = plt.figure(**kwargs)
             ax: plt.Axes
             axl: plt.Axes
             ax, axl = fig.subplots(nrows=2, height_ratios=[1, 0.3])
@@ -241,7 +242,7 @@ class RollPass(DiskElementUnit, DeformationUnit):
             return fig
 
     except ImportError:
-        def plot(self) -> 'plt.Figure':
+        def plot(self, **kwargs) -> 'plt.Figure':
             """
             Returns a matplotlib figure visualizing this instance.
 

--- a/tests/grooves/test_plot.py
+++ b/tests/grooves/test_plot.py
@@ -1,0 +1,11 @@
+import matplotlib.pyplot as plt
+
+import pyroll.core as pr
+
+
+def test_plot_groove():
+    groove = pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+
+    result = groove.plot()
+
+    result.show()

--- a/tests/profiles/test_plot.py
+++ b/tests/profiles/test_plot.py
@@ -1,0 +1,11 @@
+import matplotlib.pyplot as plt
+
+import pyroll.core as pr
+
+
+def test_plot_profile():
+    p = pr.Profile.square(side=10, corner_radius=2)
+
+    result = p.plot()
+
+    result.show()

--- a/tests/profiles/test_plot.py
+++ b/tests/profiles/test_plot.py
@@ -1,5 +1,3 @@
-import matplotlib.pyplot as plt
-
 import pyroll.core as pr
 
 

--- a/tests/roll_pass/test_plot.py
+++ b/tests/roll_pass/test_plot.py
@@ -1,0 +1,44 @@
+import matplotlib.pyplot as plt
+
+import pyroll.core as pr
+
+
+def test_plot_roll_pass_plain():
+    p = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+        ),
+        gap=1
+    )
+
+    result = p.plot()
+
+    result.show()
+
+
+def test_plot_roll_pass_ip():
+    p = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+        ),
+        gap=1
+    )
+    p.in_profile = pr.Profile.round(diameter=4)
+
+    result = p.plot()
+
+    result.show()
+
+
+def test_plot_roll_pass_op():
+    p = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+        ),
+        gap=1
+    )
+    p.out_profile = pr.Profile.square(diagonal=3)
+
+    result = p.plot()
+
+    result.show()


### PR DESCRIPTION
Closes #81 

- Mainly to enable plotting in IPython `_repr_html_` for fast visual checking while using notebooks.
- Does *not* create dependency on matplotlib, but add it as an extra `plot`.
- Methods only present if matplotlib available within current environement, otherwise raise `RuntimeError`.
- Not all types using the `ReprMixin` must implement the plot function. If not overidden, a `TypeError` is raised, which users of the `plot` method have to be aware of (`_repr_html_` just returns the property table alone in this case).