### PR TITLE
fix formatting of repr html with images

### DIFF
--- a/pyroll/core/repr.py
+++ b/pyroll/core/repr.py
@@ -72,10 +72,12 @@ class ReprMixin(ABC):
                 plt.close(plot)
                 svg = sio.getvalue()
 
-                svg = re.sub(r'height="[\d.\w]*?"', 'height="100%"', svg)
-                svg = re.sub(r'width="[\d.\w]*?"', 'width="100%"', svg)
-
-                return "<table><tr><td style='width:60%'>" + svg + "</td><td>" + table + "</td></tr></table>"
+                return (
+                        "<table>"
+                        + "<tr><td style='text-align: center'>" + svg + "</td></tr>"
+                        + "<tr><td style='text-align: left'>" + table + "</td></tr>"
+                        + "</table>"
+                )
 
         except (NotImplementedError, ImportError, AttributeError, TypeError):
             return table


### PR DESCRIPTION
Image now centered above property table.
Fixes issues with image scaling in deeply nested objects.

![Screenshot 2023-10-10 at 10-14-52 Untitled](https://github.com/pyroll-project/pyroll-core/assets/25556047/645299c7-52f1-4eed-a0a8-da5b1c592ce1)
