### PR TITLE
Display orientation

### DIFF
--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -36,6 +36,11 @@ def detect_already_rotated(self: RollPass):
                 return True
 
 
+@RollPass.orientation
+def default_orientation(self: RollPass):
+    return 0
+
+
 @RollPass.roll_force
 def roll_force(self: RollPass):
     return (self.in_profile.flow_stress + 2 * self.out_profile.flow_stress) / 3 * self.roll.contact_area

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -23,6 +23,13 @@ class RollPass(DiskElementUnit, DeformationUnit):
     true means automatic determination from hook functions of ``Rotator.rotation``.
     """
 
+    orientation = Hook[int]()
+    """
+    Orientation of the roll pass for displaying purposes. 
+    Meaning of height and width always refer to standard horizontal orientation anyway.
+    Commonly 0 (horizontal) or 90 (vertical) for two-roll passes. Other integer values are supported, too.
+    """
+
     gap = Hook[float]()
     """Gap between the rolls (outer surface)."""
 
@@ -234,6 +241,11 @@ class RollPass(DiskElementUnit, DeformationUnit):
         ax.set_aspect("equal", "datalim")
         ax.grid(lw=0.5)
 
+        def oriented(geom):
+            if self.orientation != 0:
+                return rotate(geom, self.orientation, (0, 0))
+            return geom
+
         c = []
         ipp = []
         ipr = []
@@ -241,17 +253,27 @@ class RollPass(DiskElementUnit, DeformationUnit):
         opr = []
 
         for cl in self.contour_lines:
-            c = ax.plot(*cl.xy, color="k", label="roll surface")
+            c = ax.plot(*oriented(cl).xy, color="k", label="roll surface")
 
         if self.in_profile:
-            ipp = ax.fill(*self.in_profile.cross_section.boundary.xy, alpha=0.5, color="red", label="in profile")
-            ipr = ax.fill(*self.in_profile.equivalent_rectangle.boundary.xy, fill=False, color="red", ls="--",
-                          label="in eq. rectangle")
+            ipp = ax.fill(
+                *oriented(self.in_profile.cross_section.boundary).xy,
+                alpha=0.5, color="red", label="in profile"
+            )
+            ipr = ax.fill(
+                *oriented(self.in_profile.equivalent_rectangle.boundary).xy,
+                fill=False, color="red", ls="--", label="in eq. rectangle"
+            )
 
         if self.out_profile:
-            opp = ax.fill(*self.out_profile.cross_section.boundary.xy, alpha=0.5, color="blue", label="out profile")
-            opr = ax.fill(*self.out_profile.equivalent_rectangle.boundary.xy, fill=False, color="blue", ls="--",
-                          label="out eq. rectangle")
+            opp = ax.fill(
+                *oriented(self.out_profile.cross_section.boundary).xy,
+                alpha=0.5, color="blue", label="out profile"
+            )
+            opr = ax.fill(
+                *oriented(self.out_profile.equivalent_rectangle.boundary).xy,
+                fill=False, color="blue", ls="--", label="out eq. rectangle"
+            )
 
         axl.axis("off")
         axl.legend(handles=c + ipp + opp + ipr + opr, ncols=2, loc="lower center")

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -230,7 +230,7 @@ class RollPass(DiskElementUnit, DeformationUnit):
         fig: plt.Figure = plt.figure(**kwargs)
         ax: plt.Axes
         axl: plt.Axes
-        ax, axl = fig.subplots(nrows=2, height_ratios=[1, 0.3])
+        ax = fig.subplots()
 
         if self.label:
             ax.set_title(f"Roll Pass '{self.label}'")
@@ -246,37 +246,38 @@ class RollPass(DiskElementUnit, DeformationUnit):
                 return rotate(geom, self.orientation, (0, 0))
             return geom
 
-        c = []
-        ipp = []
-        ipr = []
-        opp = []
-        opr = []
-
-        for cl in self.contour_lines:
-            c = ax.plot(*oriented(cl).xy, color="k", label="roll surface")
+        artists = []
 
         if self.in_profile:
-            ipp = ax.fill(
+            artists += ax.fill(
                 *oriented(self.in_profile.cross_section.boundary).xy,
                 alpha=0.5, color="red", label="in profile"
             )
-            ipr = ax.fill(
+            artists += ax.fill(
                 *oriented(self.in_profile.equivalent_rectangle.boundary).xy,
                 fill=False, color="red", ls="--", label="in eq. rectangle"
             )
 
         if self.out_profile:
-            opp = ax.fill(
+            artists += ax.fill(
                 *oriented(self.out_profile.cross_section.boundary).xy,
                 alpha=0.5, color="blue", label="out profile"
             )
-            opr = ax.fill(
+            artists += ax.fill(
                 *oriented(self.out_profile.equivalent_rectangle.boundary).xy,
                 fill=False, color="blue", ls="--", label="out eq. rectangle"
             )
 
-        axl.axis("off")
-        axl.legend(handles=c + ipp + opp + ipr + opr, ncols=2, loc="lower center")
+        c = None
+        for cl in self.contour_lines:
+            c = ax.plot(*oriented(cl).xy, color="k", label="roll surface")
+
+        if c is not None:
+            artists += c
+
+        ncols = len(artists) // 2 + 1
+
+        ax.legend(handles=artists, ncols=ncols, loc='lower center')
         fig.set_layout_engine('constrained')
 
         return fig

--- a/tests/roll_pass/test_roll_pass_plot.py
+++ b/tests/roll_pass/test_roll_pass_plot.py
@@ -44,6 +44,23 @@ def test_plot_roll_pass_op():
     result.show()
 
 
+def test_roll_pass_plot_complete():
+    p = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
+            nominal_radius=100
+        ),
+        gap=1,
+        rotation=0,
+        velocity=1,
+    )
+    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+
+    result = p.plot()
+
+    result.show()
+
+
 def test_roll_pass_plot_rotation():
     p = pr.RollPass(
         roll=pr.Roll(

--- a/tests/roll_pass/test_roll_pass_plot.py
+++ b/tests/roll_pass/test_roll_pass_plot.py
@@ -42,3 +42,21 @@ def test_plot_roll_pass_op():
     result = p.plot()
 
     result.show()
+
+
+def test_roll_pass_plot_rotation():
+    p = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
+            nominal_radius=100
+        ),
+        gap=1,
+        orientation=90,
+        rotation=0,
+        velocity=1,
+    )
+    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+
+    result = p.plot()
+
+    result.show()

--- a/tests/roll_pass/test_roll_pass_plot.py
+++ b/tests/roll_pass/test_roll_pass_plot.py
@@ -61,7 +61,7 @@ def test_roll_pass_plot_complete():
     result.show()
 
 
-def test_roll_pass_plot_rotation():
+def test_roll_pass_plot_orientation():
     p = pr.RollPass(
         roll=pr.Roll(
             groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
@@ -73,6 +73,77 @@ def test_roll_pass_plot_rotation():
         velocity=1,
     )
     p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+
+    result = p.plot()
+
+    result.show()
+
+
+def test_roll_pass_plot_orientation_45():
+    p = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
+            nominal_radius=100
+        ),
+        gap=1,
+        orientation=45,
+        rotation=0,
+        velocity=1,
+    )
+    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+
+    result = p.plot()
+
+    result.show()
+
+
+def test_roll_pass_plot_orientation_neg45():
+    p = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
+            nominal_radius=100
+        ),
+        gap=1,
+        orientation=-45,
+        rotation=0,
+        velocity=1,
+    )
+    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+
+    result = p.plot()
+
+    result.show()
+
+
+def test_three_roll_pass_plot_complete():
+    p = pr.ThreeRollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
+            nominal_radius=100,
+        ),
+        gap=1,
+        rotation=0,
+        velocity=1,
+    )
+    p.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
+
+    result = p.plot()
+
+    result.show()
+
+
+def test_three_roll_pass_plot_orientation():
+    p = pr.ThreeRollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
+            nominal_radius=100,
+        ),
+        gap=1,
+        rotation=0,
+        orientation=180,
+        velocity=1,
+    )
+    p.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
 
     result = p.plot()
 


### PR DESCRIPTION
Add orientation for displaying vertical, diagonal and Y configurations of roll passes as requested in personal talk by @GRPlan.
Does not effect the meaning of height and width, just affects the display in `plot()`.
Meant to be implemented in `pyroll.report` the same way.

## RollPass

`orientation=0`

![grafik](https://github.com/pyroll-project/pyroll-core/assets/25556047/94633082-1fd3-4328-8cbd-9526fb8b4d27)

`orientation=90`

![grafik](https://github.com/pyroll-project/pyroll-core/assets/25556047/2bdf4ddb-2ce4-4d24-8bb5-499d842b29f3)

`orientation=45`

![grafik](https://github.com/pyroll-project/pyroll-core/assets/25556047/24675be9-9108-4a05-a8c3-fab2679250e2)

`orientation=-45`

![grafik](https://github.com/pyroll-project/pyroll-core/assets/25556047/8a4ce3a5-ae21-45ac-888f-b935a793520f)

## ThreeRollPass

`orientation=0`

![grafik](https://github.com/pyroll-project/pyroll-core/assets/25556047/950ebcf1-098d-4ffe-873f-5caf31bfa7f3)

`orientation=180`

![grafik](https://github.com/pyroll-project/pyroll-core/assets/25556047/464adb88-df43-42ed-b1bf-347c2e3d6634)

