### PR TITLE
147 add roll pass hooks for tension and kinemtic calculations

### DIFF
--- a/pyroll/core/roll_pass/deformation_unit.py
+++ b/pyroll/core/roll_pass/deformation_unit.py
@@ -15,6 +15,9 @@ class DeformationUnit(Unit):
     elongation = Hook[float]()
     """Coefficient of elongation (change in length)."""
 
+    tension_elongation = Hook[float]()
+    """Coefficient of elongation due to tension between units. """
+
     draught = Hook[float]()
     """Coefficient of draught (change in height)."""
 
@@ -23,6 +26,9 @@ class DeformationUnit(Unit):
 
     log_elongation = Hook[float]()
     """Log. coefficient of elongation (change in length)."""
+
+    log_tension_elongation = Hook[float]()
+    """log. coefficient of elongation due to tension between units (change in length due to tension)."""
 
     log_draught = Hook[float]()
     """Log. coefficient of draught (change in height)."""

--- a/pyroll/core/roll_pass/hookimpls/deformation_unit.py
+++ b/pyroll/core/roll_pass/hookimpls/deformation_unit.py
@@ -15,7 +15,12 @@ def spread(self: DeformationUnit):
 
 @DeformationUnit.elongation
 def elongation(self: DeformationUnit):
-    return self.in_profile.cross_section.area / self.out_profile.cross_section.area
+    return self.in_profile.cross_section.area / self.out_profile.cross_section.area * self.tension_elongation
+
+
+@DeformationUnit.tension_elongation
+def tension_elongation(self: DeformationUnit):
+    return np.exp(self.log_tension_elongation)
 
 
 @DeformationUnit.log_draught
@@ -30,7 +35,12 @@ def log_spread(self: DeformationUnit):
 
 @DeformationUnit.log_elongation
 def log_elongation(self: DeformationUnit):
-    return np.log(self.elongation)
+    return np.log(self.elongation) + self.log_tension_elongation
+
+
+@DeformationUnit.log_tension_elongation
+def log_tension_elongation(self: DeformationUnit):
+    return 0
 
 
 @DeformationUnit.abs_draught

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -51,4 +51,4 @@ def surface_velocity(self: RollPass.Roll):
         if self.has_value("neutral_angle"):
             return self.roll_pass.velocity / np.cos(self.neutral_angle)
         else:
-            return self.roll_pass.velocity / np.cos(0)
+            return self.roll_pass.velocity / np.cos(self.roll_pass.exit_point)

--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -231,3 +231,13 @@ def entry_point(self: RollPass):
 @RollPass.entry_angle
 def entry_angle(self: RollPass):
     return np.arcsin(self.entry_point / self.roll.working_radius)
+
+
+@RollPass.exit_point
+def exit_point(self: RollPass):
+    return 0
+
+
+@RollPass.exit_angle
+def exit_angle(self: RollPass):
+    return np.arcsin(self.exit_point / self.roll.working_radius)

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -66,6 +66,12 @@ class RollPass(DiskElementUnit, DeformationUnit):
     entry_angle = Hook[float]()
     """Angle at which the material enters the roll gap."""
 
+    exit_point = Hook[float]()
+    """Point where the material exits the roll gap."""
+
+    exit_angle = Hook[float]()
+    """Angle at which the material exits the roll gap."""
+
     front_tension = Hook[float]()
     """Front tension acting on the current roll pass."""
 
@@ -86,6 +92,9 @@ class RollPass(DiskElementUnit, DeformationUnit):
 
     target_cross_section_filling_ratio = Hook[float]()
     """Target cross-section filling ratio of the out profile."""
+
+    forward_slip_ratio = Hook[float]()
+    """Ratio of forward slip of the roll gap."""
 
     def __init__(
             self,


### PR DESCRIPTION
Added hooks for coupled calculation between units with tensions. 
The solution to include the tension elongation can be seen as a suggestion and is still up for discussion.
Closes #147.