### PR TITLE
add inscribed circle diameter hook and impls

### DIFF
--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -97,6 +97,33 @@ def gap(self: RollPass):
         return self.height - 2 * self.roll.groove.depth
 
 
+@ThreeRollPass.inscribed_circle_diameter
+def inscribed_circle_diameter_from_gap(self: ThreeRollPass):
+    if self.has_set_or_cached("gap"):
+        half = self.roll.groove.usable_width / 2 / np.sqrt(3) + self.gap / np.sqrt(3) + self.roll.groove.depth
+        return half * 2
+
+
+@ThreeRollPass.gap
+def gap3_from_height(self: ThreeRollPass):
+    if self.has_set_or_cached("height"):
+        return (
+                self.height / 2
+                - self.roll.groove.usable_width / 2 / np.sqrt(3)
+                - self.roll.groove.depth
+        ) * np.sqrt(3)
+
+
+@ThreeRollPass.gap
+def gap3_from_icd(self: ThreeRollPass):
+    if self.has_set_or_cached("inscribed_circle_diameter"):
+        return (
+                self.inscribed_circle_diameter / 2
+                - self.roll.groove.usable_width / 2 / np.sqrt(3)
+                - self.roll.groove.depth
+        ) * np.sqrt(3)
+
+
 @RollPass.height
 def height(self):
     if self.has_set_or_cached("gap"):

--- a/pyroll/core/roll_pass/three_roll_pass.py
+++ b/pyroll/core/roll_pass/three_roll_pass.py
@@ -13,7 +13,7 @@ class ThreeRollPass(RollPass):
     """Represents a roll pass with three working rolls and 3-fold symmetry."""
 
     inscribed_circle_diameter = Hook[float]()
-    """Diameter of incribed circle between roll barrels as alternative to roll gap definition."""
+    """Diameter of inscribed circle between roll barrels as alternative to roll gap definition."""
 
     @property
     def contour_lines(self) -> List[LineString]:

--- a/pyroll/core/roll_pass/three_roll_pass.py
+++ b/pyroll/core/roll_pass/three_roll_pass.py
@@ -12,6 +12,9 @@ from ..roll import Roll as BaseRoll
 class ThreeRollPass(RollPass):
     """Represents a roll pass with three working rolls and 3-fold symmetry."""
 
+    inscribed_circle_diameter = Hook[float]()
+    """Diameter of incribed circle between roll barrels as alternative to roll gap definition."""
+
     @property
     def contour_lines(self) -> List[LineString]:
         if self._contour_lines:

--- a/tests/roll_pass/test_three_roll_pass.py
+++ b/tests/roll_pass/test_three_roll_pass.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+import shapely
 
 from pyroll.core import ThreeRollPass, Roll, CircularOvalGroove, BoxGroove
 
@@ -62,6 +63,8 @@ def test_contour_lines(g):
     shift = g.usable_width / 2 / np.sqrt(3) + rp.gap / np.sqrt(3)
     plt.axline((g.z3, -g.y3-shift), slope=np.tan(g.flank_angle), c="r", ls="--", lw=1)
     plt.axline((g.z1, -g.y1-shift), slope=np.tan(-g.pad_angle), c="r", ls="--", lw=1)
+
+    plt.plot(*shapely.Point(0,0).buffer(rp.inscribed_circle_diameter / 2).boundary.xy)
 
     plt.show()
     plt.close()


### PR DESCRIPTION
Close #121 

Works for ovals, rounds and flats. If the curvature is narrower than a circle, this method fails.