### PR TITLE
Calc Transport Length from Pass Location

### DIFF
--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -96,6 +96,9 @@ class RollPass(DiskElementUnit, DeformationUnit):
     forward_slip_ratio = Hook[float]()
     """Ratio of forward slip of the roll gap."""
 
+    location = Hook[float]()
+    """Coordinate of the passes high point in rolling direction."""
+
     def __init__(
             self,
             roll: BaseRoll,

--- a/pyroll/core/transport/hookimpls.py
+++ b/pyroll/core/transport/hookimpls.py
@@ -27,9 +27,26 @@ def environment_temperature(self):
 
 
 @Transport.length
-def length_from_roll_pass_positions(self: Transport):
-    from ..roll_pass import RollPass
+def length_from_roll_pass_positions(self: Transport, cycle):
+    if cycle:
+        return None
 
-    if self.prev.has_value("location") and self.next.has_value("location"):
-        entry = self.next.entry_point if self.next.has_value("entry_point") else 0
-        return self.next.location - self.prev.location + entry
+    from ..roll_pass import RollPass
+    next_pass = self.next_of(RollPass)
+    prev_pass = self.prev_of(RollPass)
+
+    if next_pass.has_value("location") and prev_pass.has_value("location"):
+        entry = next_pass.entry_point if next_pass.has_value("entry_point") else 0
+        length = 0
+
+        current = self
+        while not (current.next is next_pass):
+            length += current.next.length
+            current = current.next
+
+        current = self
+        while not (current.prev is prev_pass):
+            length += current.prev.length
+            current = current.prev
+
+        return next_pass.location - prev_pass.location + entry - length

--- a/pyroll/core/transport/hookimpls.py
+++ b/pyroll/core/transport/hookimpls.py
@@ -24,3 +24,12 @@ def conti_velocity(self: Transport):
 @Transport.environment_temperature
 def environment_temperature(self):
     return 293
+
+
+@Transport.length
+def length_from_roll_pass_positions(self: Transport):
+    from ..roll_pass import RollPass
+
+    if self.prev.has_value("location") and self.next.has_value("location"):
+        entry = self.next.entry_point if self.next.has_value("entry_point") else 0
+        return self.next.location - self.prev.location + entry

--- a/pyroll/core/unit/hookimpls.py
+++ b/pyroll/core/unit/hookimpls.py
@@ -23,20 +23,20 @@ def surface_area(self: Unit):
 
 
 @Unit.length
-def length(self: Unit):
-    if self.has_set_or_cached("duration"):
+def length(self: Unit, cycle):
+    if not cycle and self.has_value("duration"):
         return self.velocity * self.duration
 
 
 @Unit.duration
-def duration(self: Unit):
-    if self.has_set_or_cached("length"):
+def duration(self: Unit, cycle):
+    if not cycle and self.has_value("length"):
         return self.length / self.velocity
 
 
 @Unit.velocity
 def velocity(self: Unit):
-    if self.in_profile.has_set_or_cached("velocity"):
+    if self.in_profile.has_value("velocity"):
         return self.in_profile.velocity
 
 

--- a/tests/transport/test_transport_length.py
+++ b/tests/transport/test_transport_length.py
@@ -64,3 +64,70 @@ def test_transport_length_from_roll_pass_positions_solve(caplog):
         print(caplog.text)
 
     assert sequence["transport"].length == 100 - sequence.roll_passes[1].roll.contact_length
+
+
+def test_transport_length_from_roll_pass_positions_with_shadow():
+    sequence = pr.PassSequence([
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=None,
+                contact_length=10,
+            ),
+            location=100
+        ),
+        pr.Transport(length=5),
+        pr.Transport(label="transport"),
+        pr.Transport(length=10),
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=None,
+                contact_length=20,
+            ),
+            location=200
+        ),
+    ])
+
+    assert sequence["transport"].length == 65
+
+
+def test_transport_length_from_roll_pass_positions_solve_with_shadow(caplog):
+    caplog.set_level(logging.DEBUG, logger="pyroll")
+
+    in_profile = pr.BoxProfile(
+        width=1,
+        height=3,
+        flow_stress=1
+    )
+
+    sequence = pr.PassSequence([
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.FlatGroove(usable_width=1),
+                nominal_radius=1,
+            ),
+            rotation=0,
+            gap=2,
+            velocity=1,
+            location=100,
+        ),
+        pr.Transport(length=5),
+        pr.Transport(label="transport"),
+        pr.Transport(length=10),
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.FlatGroove(usable_width=1),
+                nominal_radius=1,
+            ),
+            rotation=0,
+            gap=1,
+            velocity=1,
+            location=200,
+        ),
+    ])
+
+    try:
+        sequence.solve(in_profile)
+    finally:
+        print(caplog.text)
+
+    assert sequence["transport"].length == 100 - sequence.roll_passes[1].roll.contact_length - 15

--- a/tests/transport/test_transport_length.py
+++ b/tests/transport/test_transport_length.py
@@ -1,0 +1,66 @@
+import logging
+
+import pyroll.core as pr
+
+
+def test_transport_length_from_roll_pass_positions():
+    sequence = pr.PassSequence([
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=None,
+                contact_length=10,
+            ),
+            location=100
+        ),
+        pr.Transport(label="transport"),
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=None,
+                contact_length=20,
+            ),
+            location=200
+        ),
+    ])
+
+    assert sequence["transport"].length == 80
+
+
+def test_transport_length_from_roll_pass_positions_solve(caplog):
+    caplog.set_level(logging.DEBUG, logger="pyroll")
+
+    in_profile = pr.BoxProfile(
+        width=1,
+        height=3,
+        flow_stress=1
+    )
+
+    sequence = pr.PassSequence([
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.FlatGroove(usable_width=1),
+                nominal_radius=1,
+            ),
+            rotation=0,
+            gap=2,
+            velocity=1,
+            location=100,
+        ),
+        pr.Transport(label="transport"),
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.FlatGroove(usable_width=1),
+                nominal_radius=1,
+            ),
+            rotation=0,
+            gap=1,
+            velocity=1,
+            location=200,
+        ),
+    ])
+
+    try:
+        sequence.solve(in_profile)
+    finally:
+        print(caplog.text)
+
+    assert sequence["transport"].length == 100 - sequence.roll_passes[1].roll.contact_length


### PR DESCRIPTION
Close #169 

- Transport `length` is calculated from `location` of adjacent roll passes (newly defined).
- Multiple transports between roll passes are allowed, but others must have a fixed length (or calculated by another hook).