### PR TITLE
Add Plotly Backend for Profiles and Roll Passes

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -11,17 +11,15 @@ path = ".venv"
 dependencies = [
     "ipython ~= 8.0",
     "pytest ~= 7.0",
-    "matplotlib ~= 3.6",
     "pyroll-report ~= 2.0.0",
     "jupyter",
-    "plotly ~= 5.18"
 ]
+features = ["plotly", "matplotlib"]
 
 [envs.test]
 path = ""
 dependencies = [
     "pytest ~= 7.0",
-    "matplotlib ~= 3.6",
 ]
 
 [[envs.test.matrix]]

--- a/hatch.toml
+++ b/hatch.toml
@@ -13,7 +13,8 @@ dependencies = [
     "pytest ~= 7.0",
     "matplotlib ~= 3.6",
     "pyroll-report ~= 2.0.0",
-    "jupyter"
+    "jupyter",
+    "plotly ~= 5.18"
 ]
 
 [envs.test]
@@ -24,7 +25,7 @@ dependencies = [
 ]
 
 [[envs.test.matrix]]
-python = ["3.9", "3.10", "3.11"]
+features = ["matplotlib", "plotly"]
 
 [envs.test.scripts]
 all = "pytest tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,12 @@ dynamic = ["version"]
 plot = [
     "matplotlib ~= 3.7"
 ]
+matplotlib = [
+    "matplotlib ~= 3.7"
+]
+plotly = [
+    "plotly ~= 5.18"
+]
 
 [project.urls]
 Homepage = "https://pyroll-project.github.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ matplotlib = [
     "matplotlib ~= 3.7"
 ]
 plotly = [
-    "plotly ~= 5.18"
+    "plotly ~= 5.18",
+    "pandas ~= 2.0"
 ]
 
 [project.urls]

--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -32,3 +32,16 @@ root_hooks.extend(
         PassSequence.log_elongation,
     ]
 )
+
+# determine available plotting backend, plotly is preferred
+try:
+    import plotly as _
+    PLOTTING_BACKEND = "plotly"
+
+except ImportError:
+    try:
+        import matplotlib as _
+        PLOTTING_BACKEND = "matplotlib"
+
+    except ImportError:
+        PLOTTING_BACKEND = None

--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -340,7 +340,6 @@ class Profile(HookHost):
         :raises ValueError: if arguments are out of range
         """
 
-
         return HexagonProfile(side, height, diagonal, corner_radius, **kwargs)
 
     def local_height(self, z: float) -> float:
@@ -390,26 +389,47 @@ class Profile(HookHost):
                 raise ValueError("Value of self.material is neither a string or a collection of strings.")
 
     def plot(self, **kwargs):
-        try:
-            import matplotlib.pyplot as plt
-        except ImportError as e:
+        from pyroll.core import PLOTTING_BACKEND
+        if PLOTTING_BACKEND is None:
             raise RuntimeError(
-                "This method is only available if matplotlib is installed in the environment. "
-                "You may install it using the 'plot' extra of pyroll-core."
-            ) from e
+                "This method is only available if matplotlib or plotly is installed in the environment. "
+                "You may install one of them using the 'plot', 'matplotlib' or 'plotly' extras of pyroll-core."
+            )
 
-        fig: plt.Figure = plt.figure(**kwargs)
-        ax: plt.Axes = fig.subplots()
+        if PLOTTING_BACKEND == "matplotlib":
+            import matplotlib.pyplot as plt
 
-        ax.set_ylabel("y")
-        ax.set_xlabel("z")
+            fig: plt.Figure = plt.figure(**kwargs)
+            ax: plt.Axes = fig.subplots()
 
-        ax.set_aspect("equal", "datalim")
-        ax.grid(lw=0.5)
+            ax.set_ylabel("y")
+            ax.set_xlabel("z")
 
-        ax.plot(*self.cross_section.boundary.xy, color="k")
-        ax.fill(*self.cross_section.boundary.xy, color="k", alpha=0.5)
-        return fig
+            ax.set_aspect("equal", "datalim")
+            ax.grid(lw=0.5)
+
+            ax.plot(*self.cross_section.boundary.xy, color="k")
+            ax.fill(*self.cross_section.boundary.xy, color="k", alpha=0.5)
+            return fig
+
+        if PLOTTING_BACKEND == "plotly":
+            import plotly.express as px
+
+            fig = px.line(
+                x=self.cross_section.boundary.xy[0],
+                y=self.cross_section.boundary.xy[1],
+                labels={"y": "y", "x": "z"},
+                template="simple_white",
+            )
+
+            fig.data[0].fill = "toself"
+
+            fig.update_yaxes(
+                scaleanchor="x",
+                scaleratio=1
+            )
+
+            return fig
 
 
 class RoundProfile(Profile):

--- a/tests/profiles/test_profile_plot.py
+++ b/tests/profiles/test_profile_plot.py
@@ -1,17 +1,24 @@
+import pytest
+
 import pyroll.core as pr
 
 
-def test_plot_profile():
-    p = pr.Profile.square(side=10, corner_radius=2)
+@pytest.mark.parametrize(
+    "p",
+    [
+        pr.Profile.square(side=10, corner_radius=2),
+        pr.Profile.hexagon(side=10, corner_radius=2)
+    ]
+)
+def test_plot_profile(p):
+    if pr.PLOTTING_BACKEND is not None:
+        result = p.plot()
+        result.show()
 
-    result = p.plot()
+        if pr.PLOTTING_BACKEND == "matplotlib":
+            from matplotlib.pyplot import Figure
+            assert isinstance(result, Figure)
 
-    result.show()
-
-
-def test_plot_hexagon_profile():
-    p = pr.Profile.hexagon(side=10, corner_radius=2)
-
-    result = p.plot()
-
-    result.show()
+        if pr.PLOTTING_BACKEND == "plotly":
+            from plotly.graph_objects import Figure
+            assert isinstance(result, Figure)

--- a/tests/roll_pass/test_roll_pass_plot.py
+++ b/tests/roll_pass/test_roll_pass_plot.py
@@ -11,7 +11,8 @@ import pyroll.core as pr
             roll=pr.Roll(
                 groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
             ),
-            gap=1
+            gap=1,
+            in_profile = pr.Profile.round(diameter=4),
         ),
         pr.RollPass(
             roll=pr.Roll(
@@ -23,7 +24,8 @@ import pyroll.core as pr
             roll=pr.Roll(
                 groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
             ),
-            gap=1
+            gap=1,
+            out_profile=pr.Profile.round(diameter=4),
         ),
         pr.RollPass(
             roll=pr.Roll(
@@ -31,8 +33,8 @@ import pyroll.core as pr
                 nominal_radius=100
             ),
             gap=1,
-            rotation=0,
-            velocity=1,
+            in_profile=pr.Profile.round(diameter=4),
+            out_profile=pr.Profile.box(height=3, width=6, corner_radius=1),
         ),
     ]
 )

--- a/tests/roll_pass/test_roll_pass_plot.py
+++ b/tests/roll_pass/test_roll_pass_plot.py
@@ -1,186 +1,107 @@
 import matplotlib.pyplot as plt
+import pytest
 
 import pyroll.core as pr
 
 
-def test_plot_roll_pass_plain():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+@pytest.mark.parametrize(
+    "rp",
+    [
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+            ),
+            gap=1
         ),
-        gap=1
-    )
-
-    result = p.plot()
-
-    result.show()
-
-
-def test_plot_roll_pass_ip():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+            ),
+            gap=1
         ),
-        gap=1
-    )
-    p.in_profile = pr.Profile.round(diameter=4)
-
-    result = p.plot()
-
-    result.show()
-
-
-def test_plot_roll_pass_op():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+            ),
+            gap=1
         ),
-        gap=1
-    )
-    p.out_profile = pr.Profile.square(diagonal=3)
-
-    result = p.plot()
-
-    result.show()
-
-
-def test_roll_pass_plot_complete():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
-            nominal_radius=100
+        pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
+                nominal_radius=100
+            ),
+            gap=1,
+            rotation=0,
+            velocity=1,
         ),
-        gap=1,
-        rotation=0,
-        velocity=1,
-    )
-    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+    ]
+)
+def test_plot_roll_pass_with_profiles_or_not(rp):
+    if pr.PLOTTING_BACKEND is not None:
+        result = rp.plot()
+        result.show()
 
-    result = p.plot()
+        if pr.PLOTTING_BACKEND == "matplotlib":
+            from matplotlib.pyplot import Figure
+            assert isinstance(result, Figure)
 
-    result.show()
-
-
-def test_roll_pass_plot_orientation_90():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
-            nominal_radius=100
-        ),
-        gap=1,
-        orientation=90,
-        rotation=0,
-        velocity=1,
-    )
-    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
-
-    result = p.plot()
-
-    result.show()
+        if pr.PLOTTING_BACKEND == "plotly":
+            from plotly.graph_objects import Figure
+            assert isinstance(result, Figure)
 
 
-def test_roll_pass_plot_orientation_horizontal():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
-            nominal_radius=100
-        ),
-        gap=1,
-        orientation="Horizontal",
-        rotation=0,
-        velocity=1,
-    )
-    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+@pytest.mark.parametrize(
+    "orientation", [0, 90, "Horizontal", 45, -45, "Vertical"]
+)
+def test_roll_pass_plot_orientation(orientation):
+    if pr.PLOTTING_BACKEND is not None:
+        rp = pr.RollPass(
+            roll=pr.Roll(
+                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
+                nominal_radius=100
+            ),
+            gap=1,
+            orientation=orientation,
+            rotation=0,
+            velocity=1,
+        )
+        rp.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+        result = rp.plot()
+        result.show()
 
-    result = p.plot()
+        if pr.PLOTTING_BACKEND == "matplotlib":
+            from matplotlib.pyplot import Figure
+            assert isinstance(result, Figure)
 
-    result.show()
-
-
-def test_roll_pass_plot_orientation_45():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
-            nominal_radius=100
-        ),
-        gap=1,
-        orientation=45,
-        rotation=0,
-        velocity=1,
-    )
-    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
-
-    result = p.plot()
-
-    result.show()
+        if pr.PLOTTING_BACKEND == "plotly":
+            from plotly.graph_objects import Figure
+            assert isinstance(result, Figure)
 
 
-def test_roll_pass_plot_orientation_neg45():
-    p = pr.RollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
-            nominal_radius=100
-        ),
-        gap=1,
-        orientation=-45,
-        rotation=0,
-        velocity=1,
-    )
-    p.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+@pytest.mark.parametrize(
+    "orientation", [0, 180, "Y", "AntiY", -180]
+)
+def test_three_roll_pass_plot_orientation(orientation):
+    if pr.PLOTTING_BACKEND is not None:
+        rp = pr.ThreeRollPass(
+            roll=pr.Roll(
+                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
+                nominal_radius=100,
+            ),
+            gap=1,
+            orientation=orientation,
+            rotation=0,
+            velocity=1,
+        )
+        rp.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
+        result = rp.plot()
+        result.show()
 
-    result = p.plot()
+        if pr.PLOTTING_BACKEND == "matplotlib":
+            from matplotlib.pyplot import Figure
+            assert isinstance(result, Figure)
 
-    result.show()
+        if pr.PLOTTING_BACKEND == "plotly":
+            from plotly.graph_objects import Figure
+            assert isinstance(result, Figure)
 
-
-def test_three_roll_pass_plot_complete():
-    p = pr.ThreeRollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
-            nominal_radius=100,
-        ),
-        gap=1,
-        rotation=0,
-        velocity=1,
-    )
-    p.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
-
-    result = p.plot()
-
-    result.show()
-
-
-def test_three_roll_pass_plot_orientation_180():
-    p = pr.ThreeRollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
-            nominal_radius=100,
-        ),
-        gap=1,
-        rotation=0,
-        orientation=180,
-        velocity=1,
-    )
-    p.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
-
-    result = p.plot()
-
-    result.show()
-
-
-def test_three_roll_pass_plot_orientation_anti_y():
-    p = pr.ThreeRollPass(
-        roll=pr.Roll(
-            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
-            nominal_radius=100,
-        ),
-        gap=1,
-        rotation=0,
-        orientation="AntiY",
-        velocity=1,
-    )
-    p.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
-
-    result = p.plot()
-
-    result.show()


### PR DESCRIPTION
Close #166 

- Added optional dependency on plotly.
- Determine which of plotly or matplotlib is available, prefer plotly if both.
- Use the respective library in `.plot()` of profiles and roll passes.