### PR TITLE
Impl Profile Contour Refinement

### DIFF
--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -183,3 +183,7 @@ class Config:
 
     STANDARD_GRAVITY = 9.80665
     """Standard acceleration of gravity g0."""
+
+    PROFILE_CONTOUR_REFINEMENT = 0
+    """Refine the line string of profile contours with more intermediate points. 
+    Higher integers mean finer. Values < 1 disable this feature."""

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -187,3 +187,6 @@ class Config:
     PROFILE_CONTOUR_REFINEMENT = 0
     """Refine the line string of profile contours with more intermediate points. 
     Higher integers mean finer. Values < 1 disable this feature."""
+
+    GROOVE_RADIUS_POINT_COUNT = 20
+    """Count of points used to represent the radii in a generic elongation groove as line string."""

--- a/pyroll/core/grooves/generic_elongation.py
+++ b/pyroll/core/grooves/generic_elongation.py
@@ -193,22 +193,22 @@ class GenericElongationGroove(GrooveBase, ReprMixin):
         yield self.z0, self.y0
 
         if not np.isclose(self.z1, self.z3):
-            for z in np.linspace(self.z1, self.z3, 20, endpoint=False):
+            for z in np.linspace(self.z1, self.z3, Config.GROOVE_RADIUS_POINT_COUNT, endpoint=False):
                 yield z, self._r1_contour_line(z)
 
         if not np.isclose(self.z3, self.z4):
             yield self.z3, self.y3
 
         if not np.isclose(self.z4, self.z5):
-            for z in np.linspace(self.z4, self.z5, 20, endpoint=False):
+            for z in np.linspace(self.z4, self.z5, Config.GROOVE_RADIUS_POINT_COUNT, endpoint=False):
                 yield z, self._r2_contour_line(z)
 
         if not np.isclose(self.z5, self.z6):
-            for z in np.linspace(self.z5, self.z6, 20, endpoint=False):
+            for z in np.linspace(self.z5, self.z6, Config.GROOVE_RADIUS_POINT_COUNT, endpoint=False):
                 yield z, self._r3_contour_line(z)
 
         if not np.isclose(self.z6, self.z7):
-            for z in np.linspace(self.z6, self.z7, 20, endpoint=False):
+            for z in np.linspace(self.z6, self.z7, Config.GROOVE_RADIUS_POINT_COUNT, endpoint=False):
                 yield z, self._r4_contour_line(z)
 
         yield self.z9, self.y9

--- a/pyroll/core/roll_pass/hookimpls/helpers.py
+++ b/pyroll/core/roll_pass/hookimpls/helpers.py
@@ -6,11 +6,12 @@ from shapely.affinity import rotate
 
 from ..roll_pass import RollPass
 from ..three_roll_pass import ThreeRollPass
+from ...profile.profile import refine_cross_section
 
 
 def out_cross_section(rp: RollPass, width: float) -> Polygon:
     poly = Polygon(np.concatenate([cl.coords for cl in rp.contour_lines]))
-    return clip_by_rect(poly, -width / 2, -math.inf, width / 2, math.inf)
+    return refine_cross_section(clip_by_rect(poly, -width / 2, -math.inf, width / 2, math.inf))
 
 
 def out_cross_section3(rp: ThreeRollPass, width: float) -> Polygon:
@@ -20,4 +21,4 @@ def out_cross_section3(rp: ThreeRollPass, width: float) -> Polygon:
         poly = clip_by_rect(poly, -math.inf, -width / 2, math.inf, math.inf)
         poly = rotate(poly, angle=120, origin=(0, 0))
 
-    return poly
+    return refine_cross_section(poly)

--- a/tests/profiles/test_constructors.py
+++ b/tests/profiles/test_constructors.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from shapely.affinity import rotate
 
-from pyroll.core import SquareGroove, Profile
+from pyroll.core import SquareGroove, Profile, Config
 
 groove = SquareGroove(0, 3, tip_depth=20, tip_angle=91)
 
@@ -143,3 +143,20 @@ def test_hexagon_errors():
         Profile.hexagon(diagonal=-1)
     with pytest.raises(ValueError):
         Profile.hexagon(side=10, corner_radius=-1)
+
+
+def test_refinement(monkeypatch):
+    p1 = Profile.square(side=10, corner_radius=1)
+
+    monkeypatch.setattr(Config, "PROFILE_CONTOUR_REFINEMENT", 50)
+
+    p2 = Profile.square(side=10, corner_radius=1)
+
+    import  matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    ax.scatter(*p1.cross_section.boundary.xy, marker="+")
+    ax.scatter(*p2.cross_section.boundary.xy, marker="x")
+    fig.show()
+
+    assert len(p1.cross_section.boundary.coords) < len(p2.cross_section.boundary.coords)


### PR DESCRIPTION
Close #170

- Helper function implemented to refine profile contours.
- Apply in profile constructors and `RollPass.OutProfile.CrossSection` impls.

With `Config.PROFILE_CONTOUR_REFINEMENT = 50`:

![image](https://github.com/pyroll-project/pyroll-core/assets/25556047/d8443949-2d6b-4704-98e8-e98138aac407)
