### PR TITLE
fix display of units in repr html

### DIFF
--- a/pyroll/core/repr.py
+++ b/pyroll/core/repr.py
@@ -48,16 +48,22 @@ class ReprMixin(ABC):
     def _repr_html_(self):
         """HTML repr for IPython."""
 
-        buf = [f"<table><tr><th colspan=2 style='text-align:center'>{html.escape(str(self), True)}</th></tr>"]
+        buf = [f"<details><summary style='font-weight:bold'>{html.escape(str(self), True)}</summary><table>"]
 
         for name, value in sorted(self.__attrs__.items()):
             if hasattr(value, "_repr_html_"):
                 r = value._repr_html_()
+            elif isinstance(value, list) or isinstance(value, set):
+                item_reprs = (
+                    item._repr_html_() if hasattr(item, "_repr_html_") else html.escape(repr(item), True)
+                    for item in value
+                )
+                r = f"<table style='margin:0'>{''.join(f'<tr><td>{item}</td></tr>' for item in item_reprs)}</table>"
             else:
                 r = html.escape(repr(value), True)
             buf.append(f"<tr><td style='text-align:left'>{html.escape(name, True)}</td><td>{r}</td></tr>")
 
-        buf.append("</table>")
+        buf.append("</table></details>")
 
         table = ''.join(buf)
 
@@ -89,7 +95,6 @@ class ReprMixin(ABC):
             )
 
         except (NotImplementedError, ImportError, AttributeError, TypeError) as e:
-            print(e)
             return table
 
     def __rich_repr__(self):


### PR DESCRIPTION
Subunits were displayed as string in rich html disply of Jupyter. Changed to display lists as one-column table. Make whole unit display a `<details>` for more compactness

![image](https://github.com/pyroll-project/pyroll-core/assets/25556047/60c5c661-3202-4e16-a293-932d129e7114)
