### PR TITLE
Add Additional Init Functions to Init the Solution Procedure for Plugins

### DIFF
--- a/pyroll/core/unit/unit.py
+++ b/pyroll/core/unit/unit.py
@@ -143,6 +143,14 @@ class Unit(HookHost):
     def __init_subclass__(cls, **kwargs):
         cls.additional_inits = []
 
+    def _execute_additional_inits(self):
+        for s in reversed(type(self).__mro__):
+            inits = getattr(s, "additional_inits", None)
+
+            if inits is not None:
+                for init in inits:
+                    init(self)
+
     def get_root_hook_results(self):
         in_profile_results = self.in_profile.evaluate_and_set_hooks()
         out_profile_results = self.out_profile.evaluate_and_set_hooks()
@@ -171,9 +179,7 @@ class Unit(HookHost):
         self.logger.info(f"Started solving of {self}.")
         start = timer()
         self.init_solve(in_profile)
-
-        for init in self.additional_inits:
-            init(self)
+        self._execute_additional_inits()
 
         for i in range(1, self.max_iteration_count):
             self.in_profile.reevaluate_cache()

--- a/tests/unit/test_additional_inits.py
+++ b/tests/unit/test_additional_inits.py
@@ -1,0 +1,26 @@
+import pytest
+from pyroll.core import Unit, Profile
+
+
+@pytest.fixture
+def unit_instance():
+    return Unit(duration=1)
+
+
+@pytest.fixture
+def profile_instance():
+    return Profile.round(1)
+
+
+def init_fun(self):
+    self.test_var = 42
+
+
+def test_additional_inits_add(unit_instance, profile_instance):
+    Unit.additional_inits.append(init_fun)
+
+    assert not getattr(unit_instance, "test_var", None)
+
+    unit_instance.solve(profile_instance)
+
+    assert getattr(unit_instance, "test_var") == 42

--- a/tests/unit/test_additional_inits.py
+++ b/tests/unit/test_additional_inits.py
@@ -2,6 +2,10 @@ import pytest
 from pyroll.core import Unit, Profile
 
 
+class SubClassUnit(Unit):
+    pass
+
+
 @pytest.fixture
 def unit_instance():
     return Unit(duration=1)
@@ -12,11 +16,10 @@ def profile_instance():
     return Profile.round(1)
 
 
-def init_fun(self):
-    self.test_var = 42
-
-
 def test_additional_inits_add(unit_instance, profile_instance):
+    def init_fun(self):
+        self.test_var = 42
+
     Unit.additional_inits.append(init_fun)
 
     assert not getattr(unit_instance, "test_var", None)
@@ -24,3 +27,29 @@ def test_additional_inits_add(unit_instance, profile_instance):
     unit_instance.solve(profile_instance)
 
     assert getattr(unit_instance, "test_var") == 42
+
+
+def test_additional_inits_subclass(unit_instance, profile_instance):
+    def init_fun(self):
+        self.test_var = 42
+
+    def init_fun2(self):
+        assert self.test_var == 42  # test for base-first evaluation order
+        self.test_var2 = 21
+
+    Unit.additional_inits.append(init_fun)
+    SubClassUnit.additional_inits.append(init_fun2)
+
+    assert not getattr(unit_instance, "test_var", None)
+
+    unit_instance.solve(profile_instance)
+
+    assert getattr(unit_instance, "test_var") == 42
+    assert not getattr(unit_instance, "test_var2", None)
+
+    sub_instance = SubClassUnit(duration=1)
+
+    sub_instance.solve(profile_instance)
+
+    assert getattr(sub_instance, "test_var") == 42
+    assert getattr(sub_instance, "test_var2") == 21


### PR DESCRIPTION
A list holding special init functions which are called just after the classic `init_solve` method while initializing the procedure in `solve`.

Add your functions to this list using `append`. Each subclass holds its own instance. Functions of base classes are evaluated first, then those of subclasses.

```python
def init_fun(self):
        self.test_var = 42

Unit.additional_inits.append(init_fun)
```