### PR TITLE
195 windows 11 pyroll run gets stuck in an endless loop due to problems with kaleido package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "numpy ~= 1.19",
     "scipy ~= 1.9",
     "shapely ~= 2.0",
-    "ezdxf"
+    "ezdxf",
 ]
 
 dynamic = ["version"]
@@ -52,7 +52,8 @@ matplotlib = [
 plotly = [
     "plotly ~= 5.18",
     "pandas ~= 2.0",
-    "kaleido"
+    "kaleido; platform_system != 'Windows'",
+    "kaleido == 0.1.0.post1; platform_system == 'Windows'"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "numpy ~= 1.19",
     "scipy ~= 1.9",
     "shapely ~= 2.0",
-    "ezdxf",
+    "ezdxf"
 ]
 
 dynamic = ["version"]

--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -34,9 +34,23 @@ root_hooks.extend(
 )
 
 # determine available plotting backend, plotly is preferred
+
+import platform
+
 try:
     import plotly as _
     PLOTTING_BACKEND = "plotly"
+
+    try:
+        import kaleido
+        try:
+            if platform.system() == 'Windows':
+                if kaleido.__version__ != '0.1.0.post1':
+                    raise ValueError("Kaleido Version 0.1.0.post1 is required to use plotly on Windows machines")
+        except AttributeError:
+            pass
+    except ImportError:
+        print("The kaleido package is required if plotly is to be used")
 
 except ImportError:
     try:


### PR DESCRIPTION
Made some changes to resolve issue #195 on our end:

Changed `pyproject.toml` to install kaleido version 0.1.0.post1 when istalling `pyroll-core[plotly]` on Windows.
- this could also be changed to also check wether it is Windows 11, as its supposedly only an issue with that, but i cant confirm/ test, wheter or not this isnt also occuring on other windows versions.

Changed `__init__.py` to, when checking for available plotting backend, also raise an error on windows machines, if the wrong kaleido version is installed:
- if the wrong kaleido version is installed this will now raise `ValueError("Kaleido Version 0.1.0.post1 is required to use plotly on Windows machines")` when importing pyroll-core
- if plotly but no kaleido is installed the message `print("The kaleido package is required if plotly is to be used")` is output when importing pyroll-core
    - this could also be changed to raise an error here, as otherwise the error will occur when trying to export a image from plotly using `to_image`