### PR TITLE
Added capability to provide roll_diameter in roll definition

### DIFF
--- a/pyroll/core/roll/hookimpls.py
+++ b/pyroll/core/roll/hookimpls.py
@@ -75,3 +75,8 @@ def heat_penetration_number(self: Roll):
 def thermal_diffusivity(self: Roll):
     if hasattr(self, "thermal_conductivity") and hasattr(self, "density") and hasattr(self, "specific_heat_capacity"):
         return self.thermal_conductivity / (self.density * self.specific_heat_capacity)
+
+
+@Roll.nominal_radius
+def nominal_radius(self: Roll):
+    return self.nominal_diameter / 2

--- a/pyroll/core/roll/roll.py
+++ b/pyroll/core/roll/roll.py
@@ -14,6 +14,9 @@ class Roll(HookHost):
     nominal_radius = Hook[float]()
     """Nominal radius."""
 
+    nominal_diameter = Hook[float]()
+    """Nominal diameter."""
+
     working_radius = Hook[float]()
     """Effective working radius (equivalent flat rolling)."""
 

--- a/tests/roll/test_nominal_diameter.py
+++ b/tests/roll/test_nominal_diameter.py
@@ -1,0 +1,11 @@
+from pyroll.core import Roll, RoundGroove
+from numpy import isclose
+
+
+def test_nominal_diameter_input():
+    roll = Roll(
+        groove=RoundGroove(r1=2, r2=10, depth=10),
+        nominal_diameter=200,
+        contact_length=50
+    )
+    assert isclose(roll.nominal_radius, 100)


### PR DESCRIPTION
Intended to close #214 

Added a new test-file and functions to convert the nominal_diameter, if provided, into the nominal_radius for further calculations.