### PR TITLE
Remove Kaleido

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pyroll-report ~= 2.0.0",
     "jupyter",
 ]
-features = ["plotly", "matplotlib"]
+features = ["plotly"]
 
 [envs.test]
 path = ""

--- a/hatch.toml
+++ b/hatch.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pyroll-report ~= 2.0.0",
     "jupyter",
 ]
-features = ["plotly"]
+features = ["plotly", "matplotlib"]
 
 [envs.test]
 path = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ matplotlib = [
 plotly = [
     "plotly ~= 5.18",
     "pandas ~= 2.0",
-    "kaleido; platform_system != 'Windows'",
-    "kaleido == 0.1.0.post1; platform_system == 'Windows'"
 ]
 
 [project.urls]

--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -33,30 +33,3 @@ root_hooks.extend(
         PassSequence.log_elongation,
     ]
 )
-
-# determine available plotting backend, plotly is preferred
-
-import platform
-
-try:
-    import plotly as _
-    PLOTTING_BACKEND = "plotly"
-
-    try:
-        import kaleido
-        try:
-            if platform.system() == 'Windows':
-                if kaleido.__version__ != '0.1.0.post1':
-                    raise ValueError("Kaleido Version 0.1.0.post1 is required to use plotly on Windows machines")
-        except AttributeError:
-            pass
-    except ImportError:
-        print("The kaleido package is required if plotly is to be used")
-
-except ImportError:
-    try:
-        import matplotlib as _
-        PLOTTING_BACKEND = "matplotlib"
-
-    except ImportError:
-        PLOTTING_BACKEND = None

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -174,7 +174,7 @@ class Config:
 
     BOLTZMANN_CONSTANT = 1.380649e-23
     """Boltzmann constant kB."""
-    
+
     STEFAN_BOLTZMANN_CONSTANT = 5.670374419e-8
     """Stefan-Boltzmann radiation constant σ."""
 
@@ -190,3 +190,12 @@ class Config:
 
     GROOVE_RADIUS_POINT_COUNT = 20
     """Count of points used to represent the radii in a generic elongation groove as line string."""
+
+    PLOT_WIDTH = 640
+    """Width of plots (using ReprMixin) in pixels."""
+
+    PLOT_HEIGHT = 480
+    """Height of plots (using ReprMixin) in pixels."""
+
+    PLOT_RESOLUTION = 100
+    """Resolution of plots in dots per inches (dpi)."""

--- a/pyroll/core/grooves/base.py
+++ b/pyroll/core/grooves/base.py
@@ -64,55 +64,35 @@ class GrooveBase(ReprMixin):
             if (v := getattr(self, n))
         }
 
-    def plot(self, **kwargs):
-        from pyroll.core import PLOTTING_BACKEND
-        if PLOTTING_BACKEND is None:
-            raise RuntimeError(
-                "This method is only available if matplotlib or plotly is installed in the environment. "
-                "You may install one of them using the 'plot', 'matplotlib' or 'plotly' extras of pyroll-core."
-            )
+    def _plot_matplotlib_(self):
+        import matplotlib.pyplot as plt
 
-        if PLOTTING_BACKEND == "matplotlib":
-            import matplotlib.pyplot as plt
+        fig: plt.Figure = plt.figure()
+        ax: plt.Axes = fig.subplots()
 
-            fig: plt.Figure = plt.figure(
-                **dict(
-                    width=640,
-                    height=480,
-                ) | kwargs
-            )
-            ax: plt.Axes = fig.subplots()
+        ax.set_ylabel("y")
+        ax.set_xlabel("z")
 
-            ax.set_ylabel("y")
-            ax.set_xlabel("z")
+        ax.set_aspect("equal", "datalim")
+        ax.grid(lw=0.5)
 
-            ax.set_aspect("equal", "datalim")
-            ax.grid(lw=0.5)
+        ax.plot(*self.contour_line.xy, color="k")
+        return fig
 
-            ax.plot(*self.contour_line.xy, color="k")
-            return fig
+    def _plot_plotly_(self):
+        import plotly.express as px
 
-        if PLOTTING_BACKEND == "plotly":
-            import plotly.express as px
+        fig = px.line(
+            x=self.contour_line.xy[0],
+            y=self.contour_line.xy[1],
+            labels={"y": "y", "x": "z"},
+        )
 
-            fig = px.line(
-                x=self.contour_line.xy[0],
-                y=self.contour_line.xy[1],
-                labels={"y": "y", "x": "z"},
-                template="simple_white",
-                width=640,
-                height=480,
-            )
+        fig.update_traces(line_color="black")
 
-            fig.update_traces(line_color="black")
+        fig.update_yaxes(
+            scaleanchor="x",
+            scaleratio=1
+        )
 
-            fig.update_yaxes(
-                scaleanchor="x",
-                scaleratio=1
-            )
-
-            fig.update(
-                **kwargs
-            )
-
-            return fig
+        return fig

--- a/pyroll/core/grooves/base.py
+++ b/pyroll/core/grooves/base.py
@@ -75,7 +75,12 @@ class GrooveBase(ReprMixin):
         if PLOTTING_BACKEND == "matplotlib":
             import matplotlib.pyplot as plt
 
-            fig: plt.Figure = plt.figure(**kwargs)
+            fig: plt.Figure = plt.figure(
+                **dict(
+                    width=640,
+                    height=480,
+                ) | kwargs
+            )
             ax: plt.Axes = fig.subplots()
 
             ax.set_ylabel("y")
@@ -95,6 +100,8 @@ class GrooveBase(ReprMixin):
                 y=self.contour_line.xy[1],
                 labels={"y": "y", "x": "z"},
                 template="simple_white",
+                width=640,
+                height=480,
             )
 
             fig.update_traces(line_color="black")
@@ -104,5 +111,8 @@ class GrooveBase(ReprMixin):
                 scaleratio=1
             )
 
-            return fig
+            fig.update(
+                **kwargs
+            )
 
+            return fig

--- a/pyroll/core/log.py
+++ b/pyroll/core/log.py
@@ -1,7 +1,12 @@
 import logging
 
+LOG_PREFIX = "pyroll.core"
+
 
 class LogMixin:
-    def __init_subclass__(cls, logger_prefix: str = "pyroll.core", **kwargs):
+    def __init_subclass__(cls, logger_prefix: str = LOG_PREFIX, **kwargs):
         cls.logger = logging.getLogger(f"{logger_prefix}.{cls.__qualname__}")
         super().__init_subclass__(**kwargs)
+
+
+global_logger = logging.getLogger(LOG_PREFIX)

--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -462,7 +462,12 @@ class Profile(HookHost):
         if PLOTTING_BACKEND == "matplotlib":
             import matplotlib.pyplot as plt
 
-            fig: plt.Figure = plt.figure(**kwargs)
+            fig: plt.Figure = plt.figure(
+                **dict(
+                    width=640,
+                    height=480,
+                ) | kwargs
+            )
             ax: plt.Axes = fig.subplots()
 
             ax.set_ylabel("y")
@@ -483,6 +488,8 @@ class Profile(HookHost):
                 y=self.cross_section.boundary.xy[1],
                 labels={"y": "y", "x": "z"},
                 template="simple_white",
+                width=640,
+                height=480,
             )
 
             fig.data[0].fill = "toself"
@@ -490,6 +497,10 @@ class Profile(HookHost):
             fig.update_yaxes(
                 scaleanchor="x",
                 scaleratio=1
+            )
+
+            fig.update(
+                **kwargs
             )
 
             return fig

--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -451,59 +451,39 @@ class Profile(HookHost):
             except TypeError:
                 raise ValueError("Value of self.material is neither a string or a collection of strings.")
 
-    def plot(self, **kwargs):
-        from pyroll.core import PLOTTING_BACKEND
-        if PLOTTING_BACKEND is None:
-            raise RuntimeError(
-                "This method is only available if matplotlib or plotly is installed in the environment. "
-                "You may install one of them using the 'plot', 'matplotlib' or 'plotly' extras of pyroll-core."
-            )
+    def _plot_matplotlib_(self):
+        import matplotlib.pyplot as plt
 
-        if PLOTTING_BACKEND == "matplotlib":
-            import matplotlib.pyplot as plt
+        fig: plt.Figure = plt.figure()
+        ax: plt.Axes = fig.subplots()
 
-            fig: plt.Figure = plt.figure(
-                **dict(
-                    width=640,
-                    height=480,
-                ) | kwargs
-            )
-            ax: plt.Axes = fig.subplots()
+        ax.set_ylabel("y")
+        ax.set_xlabel("z")
 
-            ax.set_ylabel("y")
-            ax.set_xlabel("z")
+        ax.set_aspect("equal", "datalim")
+        ax.grid(lw=0.5)
 
-            ax.set_aspect("equal", "datalim")
-            ax.grid(lw=0.5)
+        ax.plot(*self.cross_section.boundary.xy, color="k")
+        ax.fill(*self.cross_section.boundary.xy, color="k", alpha=0.5)
+        return fig
 
-            ax.plot(*self.cross_section.boundary.xy, color="k")
-            ax.fill(*self.cross_section.boundary.xy, color="k", alpha=0.5)
-            return fig
+    def _plot_plotly_(self):
+        import plotly.express as px
 
-        if PLOTTING_BACKEND == "plotly":
-            import plotly.express as px
+        fig = px.line(
+            x=self.cross_section.boundary.xy[0],
+            y=self.cross_section.boundary.xy[1],
+            labels={"y": "y", "x": "z"},
+        )
 
-            fig = px.line(
-                x=self.cross_section.boundary.xy[0],
-                y=self.cross_section.boundary.xy[1],
-                labels={"y": "y", "x": "z"},
-                template="simple_white",
-                width=640,
-                height=480,
-            )
+        fig.data[0].fill = "toself"
 
-            fig.data[0].fill = "toself"
+        fig.update_yaxes(
+            scaleanchor="x",
+            scaleratio=1
+        )
 
-            fig.update_yaxes(
-                scaleanchor="x",
-                scaleratio=1
-            )
-
-            fig.update(
-                **kwargs
-            )
-
-            return fig
+        return fig
 
 
 class RoundProfile(Profile):

--- a/pyroll/core/repr.py
+++ b/pyroll/core/repr.py
@@ -76,21 +76,19 @@ class ReprMixin(ABC):
                 import matplotlib.pyplot as plt
                 with StringIO() as sio:
                     plot.savefig(sio, format="svg")
-                    svg = sio.getvalue()
+                image = sio.getvalue()
                 plt.close(plot)
-
             if PLOTTING_BACKEND == "plotly":
-                from plotly.io import to_image
-                svg = to_image(
+                from plotly.io import to_html
+                image = to_html(
                     plot,
-                    format="svg",
-                    width=600,
-                    height=400
-                ).decode("utf-8")
+                    full_html=False,
+                    include_plotlyjs="cdn",
+                )
 
             return (
                     "<table>"
-                    + "<tr><td style='text-align: center'>" + svg + "</td></tr>"
+                    + "<tr><td style='text-align: center'>" + image + "</td></tr>"
                     + "<tr><td style='text-align: left'>" + table + "</td></tr>"
                     + "</table>"
             )

--- a/pyroll/core/repr.py
+++ b/pyroll/core/repr.py
@@ -1,6 +1,8 @@
 import html
 from abc import ABC, abstractmethod
 from io import StringIO
+from .config import Config
+from .log import global_logger
 
 
 class ReprMixin(ABC):
@@ -12,16 +14,46 @@ class ReprMixin(ABC):
     def __attrs__(self):
         raise NotImplementedError()
 
-    def plot(self, **kwargs):
-        """
-        Returns a matplotlib figure visualizing this instance.
-        It is not required to implement this method.
-        :param kwargs: keyword arguments passed to the figure constructor
+    def _plot_plotly_(self):
+        raise NotImplementedError("Plotting using plotly not available on this type.")
 
-        :raises RuntimeError: if matplotlib is not importable
-        :raises TypeError: if the current type does not support plotting
+    def _plot_matplotlib_(self):
+        raise NotImplementedError("Plotting using matplotlib not available on this type.")
+
+    def plot_plotly(self):
         """
-        raise TypeError("This type does not support plotting.")
+        Create a plot of the current object using plotly.
+        :return: a plotly figure object
+        """
+        plot = self._plot_plotly_()
+        plot.update_layout(
+            width=Config.PLOT_WIDTH,
+            height=Config.PLOT_HEIGHT,
+        )
+        return plot
+
+    def plot_matplotlib(self):
+        """
+        Create a plot of the current object using matplotlib.
+        :return: a matplotlib figure object
+        """
+        plot = self._plot_matplotlib_()
+        plot.set_size_inches(Config.PLOT_WIDTH / Config.PLOT_RESOLUTION,
+                             Config.PLOT_HEIGHT / Config.PLOT_RESOLUTION)
+        plot.set_dpi(Config.PLOT_RESOLUTION)
+        return plot
+
+    def plot(self):
+        """
+        Create a plot of the current object using an available backend.
+
+        :returns: either a plotly or matplotlib figure object
+        """
+
+        try:
+            return self.plot_plotly()
+        except (NotImplementedError, ImportError):
+            return self.plot_matplotlib()
 
     def __str__(self):
         return type(self).__qualname__
@@ -69,16 +101,16 @@ class ReprMixin(ABC):
 
         try:
             plot = self.plot()
+            ns = type(plot).__module__.split(".", 1)[0]
 
-            from pyroll.core import PLOTTING_BACKEND
-
-            if PLOTTING_BACKEND == "matplotlib":
+            if ns == "matplotlib":
                 import matplotlib.pyplot as plt
                 with StringIO() as sio:
                     plot.savefig(sio, format="svg")
-                image = sio.getvalue()
+                    image = sio.getvalue()
                 plt.close(plot)
-            if PLOTTING_BACKEND == "plotly":
+
+            if ns == "plotly":
                 from plotly.io import to_html
                 image = to_html(
                     plot,

--- a/pyroll/core/roll_pass/roll_pass.py
+++ b/pyroll/core/roll_pass/roll_pass.py
@@ -262,7 +262,12 @@ class RollPass(DiskElementUnit, DeformationUnit):
         if PLOTTING_BACKEND == "matplotlib":
             import matplotlib.pyplot as plt
 
-            fig: plt.Figure = plt.figure(**kwargs)
+            fig: plt.Figure = plt.figure(
+                **dict(
+                    width=640,
+                    height=480,
+                ) | kwargs
+            )
             ax: plt.Axes
             axl: plt.Axes
             ax = fig.subplots()
@@ -325,7 +330,9 @@ class RollPass(DiskElementUnit, DeformationUnit):
                     scaleratio=1
                 ),
                 title=f"Roll Pass '{self.label}'" if self.label else None,
-                template="simple_white"
+                template="simple_white",
+                width=640,
+                height=480,
             ))
 
             if self.in_profile:
@@ -378,5 +385,9 @@ class RollPass(DiskElementUnit, DeformationUnit):
                     showlegend=show_in_legend
                 ))
                 show_in_legend = False
+
+            fig.update(
+                **kwargs
+            )
 
             return fig

--- a/pyroll/core/shapes.py
+++ b/pyroll/core/shapes.py
@@ -4,44 +4,204 @@ from pyroll.core.repr import ReprMixin
 from shapely import Polygon, LineString, MultiPolygon, MultiLineString
 
 
-# noinspection PyAbstractClass
-class PatchedPolygon(Polygon):
-    @property
-    def height(self) -> float:
-        """Computes the height of the bounding box."""
-        return self.bounds[3] - self.bounds[1]
-
-    @property
-    def width(self) -> float:
-        """Computes the width of the bounding box."""
-        return self.bounds[2] - self.bounds[0]
-
-    @property
-    def perimeter(self) -> float:
-        """Get the perimeter of the Polygon (alias of ``Polygon.length``)."""
-        return self.length
-
-    @property
-    def __attrs__(self):
-        return {
-            "width": self.width,
-            "height": self.height,
-            "perimeter": self.perimeter,
-            "area": self.area,
-        }
+@property
+def height(self) -> float:
+    """Computes the height of the bounding box."""
+    return self.bounds[3] - self.bounds[1]
 
 
-for cls in [Polygon, MultiPolygon]:
-    cls.height = PatchedPolygon.height
-    cls.width = PatchedPolygon.width
-    cls.perimeter = PatchedPolygon.perimeter
-    cls.__attrs__ = PatchedPolygon.__attrs__
+@property
+def width(self) -> float:
+    """Computes the width of the bounding box."""
+    return self.bounds[2] - self.bounds[0]
+
+
+@property
+def perimeter(self) -> float:
+    """Get the perimeter of the Polygon (alias of ``Polygon.length``)."""
+    return self.length
+
+
+@property
+def polygon_attrs(self):
+    return {
+        "width": self.width,
+        "height": self.height,
+        "perimeter": self.perimeter,
+        "area": self.area,
+    }
+
+
+@property
+def line_string_attrs(self):
+    return {
+        "width": self.width,
+        "height": self.height,
+        "length": self.length,
+    }
+
+
+def polygon_plot_matplotlib(self: Polygon):
+    import matplotlib.pyplot as plt
+
+    fig: plt.Figure = plt.figure()
+    ax: plt.Axes = fig.subplots()
+
+    ax.set_ylabel("y")
+    ax.set_xlabel("z")
+
+    ax.set_aspect("equal", "datalim")
+    ax.grid(lw=0.5)
+
+    ax.plot(*self.boundary.xy, color="k")
+    ax.fill(*self.boundary.xy, color="k", alpha=0.5)
+    return fig
+
+
+def polygon_plot_plotly(self: Polygon):
+    import plotly.express as px
+
+    fig = px.line(
+        x=self.boundary.xy[0],
+        y=self.boundary.xy[1],
+        labels={"y": "y", "x": "z"},
+    )
+
+    fig.update_traces(
+        fill="toself"
+    )
+
+    fig.update_yaxes(
+        scaleanchor="x",
+        scaleratio=1
+    )
+
+    return fig
+
+
+def multi_polygon_plot_matplotlib(self: MultiPolygon):
+    import matplotlib.pyplot as plt
+
+    fig: plt.Figure = plt.figure()
+    ax: plt.Axes = fig.subplots()
+
+    ax.set_ylabel("y")
+    ax.set_xlabel("z")
+
+    ax.set_aspect("equal", "datalim")
+    ax.grid(lw=0.5)
+
+    for g, c in zip(self.geoms, plt.color_sequences["default"]):
+        ax.plot(*g.boundary.xy, color=c)
+        ax.fill(*g.boundary.xy, alpha=0.5, color=c)
+    return fig
+
+
+def multi_polygon_plot_plotly(self: MultiPolygon):
+    import plotly.graph_objects as pgo
+    from pandas import DataFrame
+
+    fig = pgo.Figure()
+
+    for g in self.geoms:
+        fig.add_trace(pgo.line(
+            x=[g.boundary.xy[0] for g in self.geoms],
+            y=[g.boundary.xy[1] for g in self.geoms],
+            labels={"y": "y", "x": "z"},
+        ))
+
+    fig.update_traces(
+        fill="toself"
+    )
+
+    fig.update_yaxes(
+        scaleanchor="x",
+        scaleratio=1
+    )
+
+    return fig
+
+
+def line_string_plot_matplotlib(self: LineString):
+    import matplotlib.pyplot as plt
+
+    fig: plt.Figure = plt.figure()
+    ax: plt.Axes = fig.subplots()
+
+    ax.set_ylabel("y")
+    ax.set_xlabel("z")
+
+    ax.set_aspect("equal", "datalim")
+    ax.grid(lw=0.5)
+
+    ax.plot(*self.xy, color="k")
+    return fig
+
+
+def line_string_plot_plotly(self: LineString):
+    import plotly.express as px
+
+    fig = px.line(
+        x=self.xy[0],
+        y=self.xy[1],
+        labels={"y": "y", "x": "z"},
+    )
+
+    fig.update_traces(line_color="black")
+
+    fig.update_yaxes(
+        scaleanchor="x",
+        scaleratio=1
+    )
+
+    return fig
+
+
+for cls in [
+    LineString,
+    MultiLineString,
+    Polygon,
+    MultiPolygon,
+]:
+    cls.height = height
+    cls.width = width
     cls.__str__ = ReprMixin.__str__
     cls.__repr__ = ReprMixin.__repr__
     # noinspection PyProtectedMember
     cls._repr_html_ = ReprMixin._repr_html_
     # noinspection PyProtectedMember
     cls._repr_pretty_ = ReprMixin._repr_pretty_
+    cls.plot = ReprMixin.plot
+    cls.plot_matplotlib = ReprMixin.plot_matplotlib
+    cls.plot_plotly = ReprMixin.plot_plotly
+
+for cls in [
+    Polygon,
+    MultiPolygon,
+]:
+    cls.perimeter = perimeter
+    cls.__attrs__ = polygon_attrs
+
+for cls in [
+    LineString,
+    MultiLineString,
+]:
+    cls.__attrs__ = line_string_attrs
+
+# noinspection PyProtectedMember
+Polygon._plot_matplotlib_ = polygon_plot_matplotlib
+# noinspection PyProtectedMember
+Polygon._plot_plotly_ = polygon_plot_plotly
+
+# noinspection PyProtectedMember
+MultiPolygon._plot_matplotlib_ = multi_polygon_plot_matplotlib
+# noinspection PyProtectedMember
+MultiPolygon._plot_plotly_ = multi_polygon_plot_plotly
+
+# noinspection PyProtectedMember
+LineString._plot_matplotlib_ = line_string_plot_matplotlib
+# noinspection PyProtectedMember
+LineString._plot_plotly_ = line_string_plot_plotly
 
 _RECTANGLE_CORNERS = np.asarray(
     [
@@ -72,35 +232,3 @@ def rectangle(width: float, height: float):
     rect = Polygon(points)
 
     return rect
-
-
-class PatchedLineString(LineString):
-    @property
-    def height(self) -> float:
-        """Computes the height of the bounding box."""
-        return self.bounds[3] - self.bounds[1]
-
-    @property
-    def width(self) -> float:
-        """Computes the width of the bounding box."""
-        return self.bounds[2] - self.bounds[0]
-
-    @property
-    def __attrs__(self):
-        return {
-            "width": self.width,
-            "height": self.height,
-            "length": self.length,
-        }
-
-
-for cls in [LineString, MultiLineString]:
-    cls.height = PatchedLineString.height
-    cls.width = PatchedLineString.width
-    cls.__attrs__ = PatchedLineString.__attrs__
-    cls.__str__ = ReprMixin.__str__
-    cls.__repr__ = ReprMixin.__repr__
-    # noinspection PyProtectedMember
-    cls._repr_html_ = ReprMixin._repr_html_
-    # noinspection PyProtectedMember
-    cls._repr_pretty_ = ReprMixin._repr_pretty_

--- a/tests/grooves/test_groove_plot.py
+++ b/tests/grooves/test_groove_plot.py
@@ -1,19 +1,15 @@
-import matplotlib.pyplot as plt
+import importlib.util
+
+import pytest
 
 import pyroll.core as pr
 
 
+@pytest.mark.xfail(
+    not importlib.util.find_spec("matplotlib") and not importlib.util.find_spec("plotly"),
+    reason="no plotting backend available"
+)
 def test_plot_groove():
-    if pr.PLOTTING_BACKEND is not None:
-        groove = pr.CircularOvalGroove(r1=1, r2=5, depth=1)
-        result = groove.plot()
-        result.show()
-
-        if pr.PLOTTING_BACKEND == "matplotlib":
-            from matplotlib.pyplot import Figure
-            assert isinstance(result, Figure)
-
-        if pr.PLOTTING_BACKEND == "plotly":
-            from plotly.graph_objects import Figure
-            assert isinstance(result, Figure)
-
+    groove = pr.CircularOvalGroove(r1=1, r2=5, depth=1)
+    result = groove.plot()
+    result.show()

--- a/tests/profiles/test_profile_plot.py
+++ b/tests/profiles/test_profile_plot.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import pytest
 
 import pyroll.core as pr
@@ -10,15 +12,10 @@ import pyroll.core as pr
         pr.Profile.hexagon(side=10, corner_radius=2)
     ]
 )
+@pytest.mark.xfail(
+    not importlib.util.find_spec("matplotlib") and not importlib.util.find_spec("plotly"),
+    reason="no plotting backend available"
+)
 def test_plot_profile(p):
-    if pr.PLOTTING_BACKEND is not None:
-        result = p.plot()
-        result.show()
-
-        if pr.PLOTTING_BACKEND == "matplotlib":
-            from matplotlib.pyplot import Figure
-            assert isinstance(result, Figure)
-
-        if pr.PLOTTING_BACKEND == "plotly":
-            from plotly.graph_objects import Figure
-            assert isinstance(result, Figure)
+    result = p.plot()
+    result.show()

--- a/tests/roll_pass/test_roll_pass_plot.py
+++ b/tests/roll_pass/test_roll_pass_plot.py
@@ -1,6 +1,6 @@
-import matplotlib.pyplot as plt
-import pytest
+import importlib.util
 
+import pytest
 import pyroll.core as pr
 
 
@@ -12,7 +12,7 @@ import pyroll.core as pr
                 groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1)
             ),
             gap=1,
-            in_profile = pr.Profile.round(diameter=4),
+            in_profile=pr.Profile.round(diameter=4),
         ),
         pr.RollPass(
             roll=pr.Roll(
@@ -38,72 +38,56 @@ import pyroll.core as pr
         ),
     ]
 )
+@pytest.mark.xfail(
+    not importlib.util.find_spec("matplotlib") and not importlib.util.find_spec("plotly"),
+    reason="no plotting backend available"
+)
 def test_plot_roll_pass_with_profiles_or_not(rp):
-    if pr.PLOTTING_BACKEND is not None:
-        result = rp.plot()
-        result.show()
-
-        if pr.PLOTTING_BACKEND == "matplotlib":
-            from matplotlib.pyplot import Figure
-            assert isinstance(result, Figure)
-
-        if pr.PLOTTING_BACKEND == "plotly":
-            from plotly.graph_objects import Figure
-            assert isinstance(result, Figure)
+    result = rp.plot()
+    result.show()
 
 
 @pytest.mark.parametrize(
     "orientation", [0, 90, "Horizontal", 45, -45, "Vertical"]
 )
+@pytest.mark.xfail(
+    not importlib.util.find_spec("matplotlib") and not importlib.util.find_spec("plotly"),
+    reason="no plotting backend available"
+)
 def test_roll_pass_plot_orientation(orientation):
-    if pr.PLOTTING_BACKEND is not None:
-        rp = pr.RollPass(
-            roll=pr.Roll(
-                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
-                nominal_radius=100
-            ),
-            gap=1,
-            orientation=orientation,
-            rotation=0,
-            velocity=1,
-        )
-        rp.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
-        result = rp.plot()
-        result.show()
-
-        if pr.PLOTTING_BACKEND == "matplotlib":
-            from matplotlib.pyplot import Figure
-            assert isinstance(result, Figure)
-
-        if pr.PLOTTING_BACKEND == "plotly":
-            from plotly.graph_objects import Figure
-            assert isinstance(result, Figure)
+    rp = pr.RollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1),
+            nominal_radius=100
+        ),
+        gap=1,
+        orientation=orientation,
+        rotation=0,
+        velocity=1,
+    )
+    rp.solve(pr.Profile.box(height=6, width=4, flow_stress=100e6))
+    result = rp.plot()
+    result.show()
 
 
 @pytest.mark.parametrize(
     "orientation", [0, 180, "Y", "AntiY", -180]
 )
+@pytest.mark.xfail(
+    not importlib.util.find_spec("matplotlib") and not importlib.util.find_spec("plotly"),
+    reason="no plotting backend available"
+)
 def test_three_roll_pass_plot_orientation(orientation):
-    if pr.PLOTTING_BACKEND is not None:
-        rp = pr.ThreeRollPass(
-            roll=pr.Roll(
-                groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
-                nominal_radius=100,
-            ),
-            gap=1,
-            orientation=orientation,
-            rotation=0,
-            velocity=1,
-        )
-        rp.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
-        result = rp.plot()
-        result.show()
-
-        if pr.PLOTTING_BACKEND == "matplotlib":
-            from matplotlib.pyplot import Figure
-            assert isinstance(result, Figure)
-
-        if pr.PLOTTING_BACKEND == "plotly":
-            from plotly.graph_objects import Figure
-            assert isinstance(result, Figure)
-
+    rp = pr.ThreeRollPass(
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(r1=1, r2=5, depth=1, pad_angle=30),
+            nominal_radius=100,
+        ),
+        gap=1,
+        orientation=orientation,
+        rotation=0,
+        velocity=1,
+    )
+    rp.solve(pr.Profile.round(diameter=7.5, flow_stress=100e6))
+    result = rp.plot()
+    result.show()


### PR DESCRIPTION
To prevent errors by kaleido in default setup (see #195), plotly plots are not converted to static images anymore by default (so kaleido is not needed and therefore dependency can be removed). This also enables interactive elements in `.plot()` and `._repr_html_()`.

The plotting API is also refactored to force some figure defaults for both backends.
Users of `ReprMixin` now must only override `_plot_plotly_` and/or `_plot_matplotlib_` methods to enable plotting. They must return a figure object of the respective backend.