### PR TITLE
238 contact area of three roll passes

### DIFF
--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -412,7 +412,9 @@ class Profile(HookHost):
             coords
         )
 
-        intersection = vline.intersection(self.cross_section)
+        tolerance = 1e-12
+
+        intersection = vline.intersection(self.cross_section.buffer(tolerance))
 
         return intersection.length
 
@@ -423,7 +425,9 @@ class Profile(HookHost):
             coords
         )
 
-        intersection = hline.intersection(self.cross_section)
+        tolerance = 1e-12
+
+        intersection = hline.intersection(self.cross_section.buffer(tolerance))
 
         return intersection.length
 

--- a/pyroll/core/roll_pass/hookimpls/deformation_unit.py
+++ b/pyroll/core/roll_pass/hookimpls/deformation_unit.py
@@ -94,13 +94,20 @@ def zener_holomon_parameter(self: DeformationUnit):
 def contact_contour_lines(self: DeformationUnit.Profile):
     if isinstance(self.unit, RollPass):
         rp = self.unit
-        upper_groove_cl = translate(rp.roll.contour_line, yoff=rp.gap / 2)
-        lower_groove_cl = rotate(upper_groove_cl, angle=180, origin=(0, 0))
+        tolerance = 1e-9
 
-        upper_contact_contour = linemerge(upper_groove_cl.intersection(self.cross_section.exterior))
-        lower_contact_contour = linemerge(lower_groove_cl.intersection(self.cross_section.exterior))
+        if "3fold" in self.classifiers:
+            left_contact_contour = rp.contour_lines[0].intersection(self.cross_section.exterior.buffer(tolerance))
+            lower_contact_contour = rp.contour_lines[1].intersection(self.cross_section.exterior.buffer(tolerance))
+            right_contact_contour = rp.contour_lines[2].intersection(self.cross_section.exterior.buffer(tolerance))
 
-        return [upper_contact_contour, lower_contact_contour]
+            return [left_contact_contour, lower_contact_contour, right_contact_contour]
+
+        else:
+            upper_contact_contour = rp.contour_lines[0].intersection(self.cross_section.exterior.buffer(tolerance))
+            lower_contact_contour = rp.contour_lines[1].intersection(self.cross_section.exterior.buffer(tolerance))
+
+            return [upper_contact_contour, lower_contact_contour]
     else:
         return None
 

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -27,7 +27,7 @@ def contact_length_square_oval(self: RollPass.Roll):
 @RollPass.Roll.contact_area
 def contact_area(self: RollPass.Roll):
     if "3fold" in self.roll_pass.classifiers:
-        in_profile_local_width = self.roll_pass.in_profile.local_width(-self.roll_pass.in_profile.height / 2 * 0.999)
+        in_profile_local_width = self.roll_pass.in_profile.local_width(-self.roll_pass.in_profile.height / 2)
         return (in_profile_local_width + self.roll_pass.out_profile.contact_lines[1].width) / 2 * self.contact_length
     else:
         return (self.roll_pass.in_profile.width + self.roll_pass.out_profile.width) / 2 * self.contact_length

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ..roll_pass import RollPass
+from ..three_roll_pass import ThreeRollPass
 
 
 @RollPass.Roll.roll_torque
@@ -26,6 +27,12 @@ def contact_length_square_oval(self: RollPass.Roll):
 @RollPass.Roll.contact_area
 def contact_area(self: RollPass.Roll):
     return (self.roll_pass.in_profile.width + self.roll_pass.out_profile.width) / 2 * self.contact_length
+
+
+@ThreeRollPass.Roll.contact_area
+def contact_area3(self: RollPass.Roll):
+    in_profile_local_width = self.roll_pass.in_profile.local_width(-self.roll_pass.in_profile.height / 2 * 0.999)
+    return (in_profile_local_width + self.roll_pass.out_profile.contact_lines[1].width) / 2 * self.contact_length
 
 
 @RollPass.Roll.center

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -26,13 +26,11 @@ def contact_length_square_oval(self: RollPass.Roll):
 
 @RollPass.Roll.contact_area
 def contact_area(self: RollPass.Roll):
-    return (self.roll_pass.in_profile.width + self.roll_pass.out_profile.width) / 2 * self.contact_length
-
-
-@ThreeRollPass.Roll.contact_area
-def contact_area3(self: RollPass.Roll):
-    in_profile_local_width = self.roll_pass.in_profile.local_width(-self.roll_pass.in_profile.height / 2 * 0.999)
-    return (in_profile_local_width + self.roll_pass.out_profile.contact_lines[1].width) / 2 * self.contact_length
+    if "3fold" in self.roll_pass.classifiers:
+        in_profile_local_width = self.roll_pass.in_profile.local_width(-self.roll_pass.in_profile.height / 2 * 0.999)
+        return (in_profile_local_width + self.roll_pass.out_profile.contact_lines[1].width) / 2 * self.contact_length
+    else:
+        return (self.roll_pass.in_profile.width + self.roll_pass.out_profile.width) / 2 * self.contact_length
 
 
 @RollPass.Roll.center

--- a/tests/profiles/test_profile_contours.py
+++ b/tests/profiles/test_profile_contours.py
@@ -37,7 +37,7 @@ def test_plot_profile_contact_contours():
     plt.figure(dpi=300)
     plt.axes().set_aspect("equal")
     for ccl in rp.out_profile.contact_lines:
-        plt.plot(*rp.out_profile.contact_lines[0].xy, color='C0')
+        plt.plot(*ccl.xy, color='C0')
     plt.show()
     plt.close()
 

--- a/tests/profiles/test_profile_contours_3fold.py
+++ b/tests/profiles/test_profile_contours_3fold.py
@@ -1,0 +1,50 @@
+import pytest
+
+import pyroll.core as pr
+import matplotlib.pyplot as plt
+
+from shapely.geometry import LineString
+
+
+def test_plot_profile_contact_contours():
+    ip = pr.Profile.round(
+        diameter=55e-3,
+        temperature=1200 + 273.15,
+        strain=0,
+        material=["C45", "steel"],
+        flow_stress=100e6,
+        length=1,
+    )
+
+    rp = pr.ThreeRollPass(
+        label="Oval I",
+        roll=pr.Roll(
+            groove=pr.CircularOvalGroove(
+                depth=8e-3,
+                r1=6e-3,
+                r2=40e-3,
+                pad_angle=30
+            ),
+            nominal_radius=160e-3,
+            rotational_frequency=1
+        ),
+        gap=2e-3,
+    )
+
+    rp.solve(ip)
+
+    plt.figure(dpi=300)
+    plt.axes().set_aspect("equal")
+    for ccl in rp.out_profile.contact_lines:
+        plt.plot(*ccl.xy, color='C0')
+    plt.show()
+    plt.close()
+
+    plt.figure(dpi=300)
+    # plt.axes().set_aspect("equal")
+    for cca, ccl in zip(rp.out_profile.contact_angles, rp.out_profile.contact_lines):
+        x, y = ccl.xy
+        x = x[1:-1]
+        plt.plot(x, cca)
+    plt.show()
+    plt.close()

--- a/tests/roll/test_roll_contact_areas.py
+++ b/tests/roll/test_roll_contact_areas.py
@@ -1,0 +1,120 @@
+import plotly.graph_objs as go
+from plotly.subplots import make_subplots
+import numpy as np
+import pytest
+from shapely.geometry import Polygon
+import matplotlib.pyplot as plt
+
+import pyroll.core as pr
+
+
+@pytest.fixture(scope="module")
+def main_fig():
+    fig = make_subplots(rows=3, cols=5)
+    yield fig
+    fig.update_layout(title="Contact Areas for Different Profiles")
+    fig.show()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def subplot_index():
+    index = {'count': 0}
+    yield index
+
+
+ips = {
+    "round": pr.Profile.round(diameter=30e-3, temperature=1200 + 273.15, material=["C45", "Steel"], length=1, flow_stress=100e6),
+    "square": pr.Profile.square(side=30e-3, temperature=1200 + 273.15, material=["C45", "Steel"], length=1, flow_stress=100e6),
+    "hexagon": pr.Profile.hexagon(height=30e-3, temperature=1200 + 273.15, material=["C45", "Steel"], length=1, flow_stress=100e6),
+    "box": pr.Profile.box(height=30e-3, width=30e-3, temperature=1200 + 273.15, material=["C45", "Steel"], length=1, flow_stress=100e6),
+    "diamond": pr.Profile.diamond(height=30e-3, width=50e-3, temperature=1200 + 273.15, material=["C45", "Steel"], length=1, flow_stress=100e6),
+    "oval": pr.Profile.from_groove(pr.CircularOvalGroove(r1=1e-3, depth=12e-3, usable_width=45e-3), filling=1, height=26e-3, flow_stress=100e6, material=["C45", "Steel"])
+}
+
+gs = {
+    "flat": pr.FlatGroove(usable_width=40e-3),
+    "oval": pr.CircularOvalGroove(r1=1e-3, depth=10e-3, usable_width=40e-3),
+    "square": pr.SquareGroove(r1=1e-3, r2=5e-3, tip_angle=90, tip_depth=15e-3),
+    "round": pr.RoundGroove(r1=1e-3, depth=15e-3, usable_width=31e-3),
+}
+
+combinations = [
+    (gs["flat"], ips["round"]),
+    (gs["flat"], ips["square"]),
+    (gs["flat"], ips["hexagon"]),
+    (gs["flat"], ips["box"]),
+    (gs["flat"], ips["diamond"]),
+    (gs["oval"], ips["round"]),
+    (gs["oval"], ips["square"]),
+    (gs["oval"], ips["hexagon"]),
+    (gs["oval"], ips["box"]),
+    (gs["square"], ips["diamond"]),
+    (gs["square"], ips["oval"]),
+    (gs["round"], ips["square"]),
+    (gs["round"], ips["diamond"]),
+    (gs["round"], ips["oval"])
+]
+
+
+@pytest.mark.parametrize("g, ip", combinations)
+def test_plot_contact_areas_two_rolls(g, ip, main_fig, subplot_index):
+    gap = 2e-3
+    if "flat" in g.classifiers:
+        gap = 20e-3
+
+    rp = pr.RollPass(
+        label="test",
+        roll=pr.Roll(
+            groove=g,
+            nominal_radius=150e-3,
+            rotational_frequency=1,
+        ),
+        gap=gap
+    )
+
+    rp.solve(ip)
+
+    fig = rp.plot()
+
+    ca = contact_area(rp)
+    x_coords, y_coords = ca.exterior.xy
+
+    x_coords = list(x_coords)
+    y_coords = list(y_coords)
+
+    fig.add_trace(go.Scatter(
+        x=x_coords,
+        y=y_coords,
+        mode="lines",
+        fill="toself",
+        line=dict(color="green"),
+        fillcolor="rgba(0, 255, 0, 0.3)",
+        name="Contact Area"
+    ))
+
+    idx = subplot_index['count']
+    row = (idx // 5) + 1
+    col = (idx % 5) + 1
+
+    subplot_index['count'] += 1
+
+    for trace in fig.data:
+        main_fig.add_trace(trace, row=row, col=col)
+
+    roll_contact_area = rp.roll.contact_area
+
+    assert np.isclose(roll_contact_area, ca.area, rtol=1e-3)
+
+
+def contact_area(rp):
+    x1 = -rp.out_profile.width / 2
+    x2 = rp.out_profile.width / 2
+    x3 = rp.in_profile.width / 2
+    x4 = -rp.in_profile.width / 2
+    y1 = -rp.roll.contact_length / 2
+    y2 = -rp.roll.contact_length / 2
+    y3 = rp.roll.contact_length / 2
+    y4 = rp.roll.contact_length / 2
+
+    coordinates = [(x1, y1), (x2, y2), (x3, y3), (x4, y4), (x1, y1)]
+    return Polygon(coordinates)

--- a/tests/roll/test_roll_contact_areas_3fold.py
+++ b/tests/roll/test_roll_contact_areas_3fold.py
@@ -1,0 +1,120 @@
+import plotly.graph_objs as go
+from plotly.subplots import make_subplots
+import numpy as np
+import pytest
+from shapely.geometry import Polygon
+import matplotlib.pyplot as plt
+
+import pyroll.core as pr
+
+
+@pytest.fixture(scope="module")
+def main_fig():
+    fig = make_subplots(rows=2, cols=4)
+    yield fig
+    fig.update_layout(title="Contact Areas for Different Profiles")
+    fig.show()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def subplot_index():
+    index = {'count': 0}
+    yield index
+
+
+ips = {
+    "round": pr.Profile.round(diameter=20e-3, temperature=1200 + 273.15, material=["C45", "Steel"], length=1, flow_stress=100e6)
+}
+
+gs = {
+    "flat": pr.FlatGroove(usable_width=20e-3, pad_angle=30),
+    "oval1": pr.CircularOvalGroove(r1=1e-3, r2=12e-3, depth=3.3e-3, pad_angle=30),
+    "oval2": pr.CircularOvalGroove(r1=1e-3, r2=12e-3, depth=3.3e-3, pad_angle=30),
+    "round1": pr.RoundGroove(r1=1e-3, r2=9.6e-3, depth=4.3e-3, pad_angle=30),
+    "round2": pr.RoundGroove(r1=1e-3, r2=8.9e-3, depth=3.9e-3, pad_angle=30),
+}
+
+combinations = [
+    (gs["flat"], gs["flat"], ips["round"]),
+    (gs["oval1"], gs["oval2"], ips["round"]),
+    (gs["round1"], gs["round2"], ips["round"]),
+    (gs["round1"], gs["oval2"], ips["round"]),
+    (gs["round1"], gs["flat"], ips["round"]),
+    (gs["oval1"], gs["flat"], ips["round"]),
+    (gs["round1"], gs["flat"], ips["round"]),
+    (gs["oval1"], gs["flat"], ips["round"]),
+]
+
+
+@pytest.mark.parametrize("g1, g2, ip", combinations)
+def test_plot_contact_areas(g1, g2, ip, main_fig, subplot_index):
+
+    ps = pr.PassSequence([
+        pr.ThreeRollPass(
+            label="Pass1",
+            roll=pr.Roll(
+                groove=g1,
+                nominal_radius=150e-3,
+                rotational_frequency=1,
+            ),
+            inscribed_circle_diameter=18e-3
+        ),
+        pr.ThreeRollPass(
+            label="Pass2",
+            roll=pr.Roll(
+                groove=g2,
+                nominal_radius=150e-3,
+                rotational_frequency=1,
+            ),
+            inscribed_circle_diameter=17e-3
+        )
+    ])
+
+    rp = ps.solve(ip)
+
+    fig = ps[-1].plot()
+
+    ca = contact_area(ps[-1])
+    x_coords, y_coords = ca.exterior.xy
+
+    x_coords = list(x_coords)
+    y_coords = list(y_coords)
+
+    fig.add_trace(go.Scatter(
+        x=x_coords,
+        y=y_coords,
+        mode="lines",
+        fill="toself",
+        line=dict(color="green"),
+        fillcolor="rgba(0, 255, 0, 0.3)",
+        name="Contact Area"
+    ))
+
+    idx = subplot_index['count']
+    row = (idx // 4) + 1
+    col = (idx % 4) + 1
+
+    subplot_index['count'] += 1
+
+    for trace in fig.data:
+        main_fig.add_trace(trace, row=row, col=col)
+
+    roll_contact_area = ps[-1].roll.contact_area
+
+    assert np.isclose(roll_contact_area, ca.area, rtol=1e-3)
+
+
+def contact_area(rp):
+    in_profile_local_width = rp.in_profile.local_width(-rp.in_profile.height / 2 * 0.999)
+
+    x1 = -rp.out_profile.contact_lines[1].width / 2
+    x2 = rp.out_profile.contact_lines[1].width / 2
+    x3 = in_profile_local_width / 2
+    x4 = -in_profile_local_width / 2
+    y1 = -rp.roll.contact_length / 2
+    y2 = -rp.roll.contact_length / 2
+    y3 = rp.roll.contact_length / 2
+    y4 = rp.roll.contact_length / 2
+
+    coordinates = [(x1, y1), (x2, y2), (x3, y3), (x4, y4), (x1, y1)]
+    return Polygon(coordinates)

--- a/tests/roll/test_roll_contact_areas_3fold.py
+++ b/tests/roll/test_roll_contact_areas_3fold.py
@@ -103,9 +103,15 @@ def test_plot_contact_areas(g1, g2, ip, main_fig, subplot_index):
 
     assert np.isclose(roll_contact_area, ca.area, rtol=1e-3)
 
+    y_coords = [point[1] for point in ps[-1].in_profile.cross_section.exterior.coords[:-1]]
+    sorted_y_coords = sorted(y_coords)
+    lowest_two_y = sorted_y_coords[:2]
+    diff = lowest_two_y[1] - lowest_two_y[0]
+    print(f"Two lowest y-coords: [{lowest_two_y[0]:.30f}, {lowest_two_y[1]:.30f}] \t diff: {diff:.30f}")
+
 
 def contact_area(rp):
-    in_profile_local_width = rp.in_profile.local_width(-rp.in_profile.height / 2 * 0.999)
+    in_profile_local_width = rp.in_profile.local_width(-rp.in_profile.height / 2)
 
     x1 = -rp.out_profile.contact_lines[1].width / 2
     x2 = rp.out_profile.contact_lines[1].width / 2

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -88,7 +88,7 @@ def test_solve(tmp_path: Path, caplog):
         report = pyroll.report.report(sequence)
 
         report_file = tmp_path / "report.html"
-        report_file.write_text(report)
+        report_file.write_text(report, encoding="utf-8")
         print(report_file)
         webbrowser.open(report_file.as_uri())
 

--- a/tests/test_solve_disks.py
+++ b/tests/test_solve_disks.py
@@ -69,7 +69,7 @@ def test_solve_disks(tmp_path: Path, caplog, monkeypatch):
         report = pyroll.report.report(sequence)
 
         report_file = tmp_path / "report.html"
-        report_file.write_text(report)
+        report_file.write_text(report, encoding="utf-8")
         print(report_file)
         webbrowser.open(report_file.as_uri())
 

--- a/tests/test_solve_spreading.py
+++ b/tests/test_solve_spreading.py
@@ -98,7 +98,7 @@ def test_solve(tmp_path: Path, caplog):
         report = pyroll.report.report(sequence)
 
         report_file = tmp_path / "report.html"
-        report_file.write_text(report)
+        report_file.write_text(report, encoding="utf-8")
         print(report_file)
         webbrowser.open(report_file.as_uri())
 


### PR DESCRIPTION
Changed the Contact area calculation so that its more representative for three-roll rolling.

Also enhanced the contact_lines property to handle ThreeRollPasses correctly, as this is also required for coming changes in the Zouhar-Package.

Currently there is also a factor 0.999 necessary to correctly calculate the in_profile local_width - probably due to small numerical deviations.