### PR TITLE
impl a helper function for construction grooves by name

### DIFF
--- a/pyroll/core/grooves/__init__.py
+++ b/pyroll/core/grooves/__init__.py
@@ -25,3 +25,36 @@ from .flat import FlatGroove
 from .hexagonal import HexagonalGroove
 
 from .equivalent_ripped_groove import EquivalentRibbedGroove
+
+def create_groove_by_type_name(type_name: str, **kwargs) -> GrooveBase:
+    """
+    Helper function to create a groove instance by giving a type name and respective keyword arguments.
+    Supports all grooves from the ``pyroll.core.grooves`` namespace as well as from all currently loaded modules.
+    The former take precedence.
+
+    :param type_name: the name of the groove-type either exactly as the respective class name or with words
+                      separated by spaces, dashes or underscores where the word capitalization is ignored
+    :param kwargs: keyword arguments for constructing the respective groove,
+                   allowed arguments depend on the actual groove-type
+    """
+    import re
+    type_name = re.sub(r"[\s\-_.]+(\w)", lambda m: m.group(1).capitalize(), type_name.title())
+    type_name = type_name if type_name.endswith("Groove") else type_name + "Groove"
+
+    import sys
+
+    groove_cls = getattr(sys.modules[__name__], type_name, None) # try to get classes of grooves package first
+
+    # otherwise scan over all loaded modules
+    if not groove_cls:
+        for mod in reversed(sys.modules.values()):
+            groove_cls = getattr(mod, type_name, None)
+
+            if groove_cls:
+                break
+
+    if not groove_cls:
+        raise ValueError(f"No groove class named {type_name} found in loaded modules.")
+
+    return groove_cls(**kwargs)
+

--- a/tests/grooves/test_create_groove.py
+++ b/tests/grooves/test_create_groove.py
@@ -1,0 +1,20 @@
+import pyroll.core as pr
+import pytest
+
+from pyroll.core.roll_pass.hookimpls.roll_pass import usable_width
+
+
+@pytest.mark.parametrize(["name", "args", "expected_class"],
+    [
+        ("box", dict(r1=1, r2=1, usable_width=10, depth=3, flank_angle=80), pr.BoxGroove),
+        ("circular oval", dict(r1=1, r2=20, depth=3), pr.CircularOvalGroove),
+        ("circular-oval", dict(r1=1, r2=20, depth=3), pr.CircularOvalGroove),
+        ("circular_oval", dict(r1=1, r2=20, depth=3), pr.CircularOvalGroove),
+        ("circular Oval", dict(r1=1, r2=20, depth=3), pr.CircularOvalGroove),
+        ("swedish-oval groove", dict(r1=1, r2=1, depth=3, usable_width=10, ground_width=6), pr.SwedishOvalGroove),
+    ]
+)
+def test_create_groove(name: str, args: dict, expected_class: type):
+    inst = pr.create_groove_by_type_name(name, **args)
+
+    assert isinstance(inst, expected_class)


### PR DESCRIPTION
enables grooves construction like that

```python
import pyroll.core as pr

groove = pr.create_groove_by_type_name("swedish-oval groove", r1=1, r2=1, depth=3, usable_width=10, ground_width=6)
```