### PR TITLE
262 add hooks for technological correct profile and contour line orientation

### DIFF
--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -32,5 +32,7 @@ root_hooks.extend(
         BaseRollPass.OutProfile.cross_section_error,
         BaseRollPass.OutProfile.velocity,
         PassSequence.log_elongation,
+        BaseRollPass.OutProfile.technologically_orientated_cross_section,
+        BaseRollPass.technologically_orientated_contour_lines,
     ]
 )

--- a/pyroll/core/profile/profile.py
+++ b/pyroll/core/profile/profile.py
@@ -18,6 +18,9 @@ class Profile(HookHost):
     cross_section = Hook[Polygon]()
     """Shape of the profile's cross-section."""
 
+    technologically_orientated_cross_section = Hook[Polygon]()
+    """Shape of the profile's cross-section with technologically correct orientation."""
+
     classifiers = Hook[Set[str]]()
     """Classifiers of the profile's shape's type."""
 

--- a/pyroll/core/roll_pass/base.py
+++ b/pyroll/core/roll_pass/base.py
@@ -3,7 +3,7 @@ from typing import List, Union, cast
 
 import numpy as np
 from shapely.affinity import rotate
-from shapely.geometry import Polygon, MultiPolygon
+from shapely.geometry import Polygon, MultiPolygon, LineString, MultiLineString
 
 from ..disk_elements import DiskElementUnit
 from ..hooks import Hook
@@ -98,6 +98,9 @@ class BaseRollPass(DiskElementUnit, DeformationUnit):
 
     location = Hook[float]()
     """Coordinate of the passes high point in rolling direction."""
+
+    technologically_orientated_contour_lines = Hook[MultiLineString]()
+    """Contour line of the roll pass with technologically correct orientation."""
 
     def __init__(
             self,
@@ -236,8 +239,9 @@ class BaseRollPass(DiskElementUnit, DeformationUnit):
             "classifiers": self.classifiers,
         }
 
-    def _get_oriented_geom(self, geom):
-        orientation = self.orientation
+    def _get_oriented_geom(self, geom, orientation=None):
+        if orientation is None:
+            orientation = self.orientation
 
         if isinstance(orientation, str):
             if orientation.lower() in ["horizontal", "h", "y"]:

--- a/pyroll/core/roll_pass/hookimpls/roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/roll_pass.py
@@ -1,7 +1,7 @@
 import math
 
 import numpy as np
-from shapely import Polygon, difference, clip_by_rect
+from shapely import Polygon, difference, clip_by_rect, MultiLineString
 from shapely.ops import linemerge
 
 from ..base import BaseRollPass
@@ -291,3 +291,14 @@ def default_front_tension(self: RollPass):
 @RollPass.back_tension
 def default_back_tension(self: RollPass):
     return 0
+
+
+@BaseRollPass.technologically_orientated_contour_lines
+def technologically_correctly_orientated_contour_lines(self: BaseRollPass):
+    return MultiLineString([self._get_oriented_geom(cl) for cl in self.contour_lines])
+
+
+@BaseRollPass.OutProfile.technologically_orientated_cross_section
+def technologically_correctly_orientated_cross_section(self: BaseRollPass.OutProfile):
+    return self.roll_pass._get_oriented_geom(self.cross_section, orientation=self.roll_pass.orientation)
+


### PR DESCRIPTION
Added attributes and hooks for technologically correctly orientated contour lines and profiles.

Closes pyroll-project/pyroll-export#6