### PR TITLE
use multi line strings in all contour-line like properties and hooks

### DIFF
--- a/pyroll/core/roll_pass/base.py
+++ b/pyroll/core/roll_pass/base.py
@@ -3,6 +3,7 @@ from abc import abstractmethod, ABC
 from typing import List, Union, cast
 
 import numpy as np
+import shapely
 from shapely.affinity import rotate
 from shapely.geometry import Polygon, MultiPolygon, LineString, MultiLineString
 
@@ -114,7 +115,7 @@ class BaseRollPass(DiskElementUnit, DeformationUnit, ABC):
 
     @property
     @abstractmethod
-    def contour_lines(self):
+    def contour_lines(self) -> MultiLineString:
         """List of line strings bounding the roll pass at the high point."""
         raise NotImplementedError()
 
@@ -278,7 +279,7 @@ class BaseRollPass(DiskElementUnit, DeformationUnit, ABC):
             )
 
         c = None
-        for cl in self.contour_lines:
+        for cl in self.contour_lines.geoms:
             c = ax.plot(*self._get_oriented_geom(cl).xy, color="k", label="roll surface")
 
         if c is not None:
@@ -348,7 +349,7 @@ class BaseRollPass(DiskElementUnit, DeformationUnit, ABC):
             ))
 
         show_in_legend = True
-        for cl in self.contour_lines:
+        for cl in self.contour_lines.geoms:
             coords = self._get_oriented_geom(cl).xy
             fig.add_trace(go.Scatter(
                 x=np.array(coords[0]),

--- a/pyroll/core/roll_pass/deformation_unit.py
+++ b/pyroll/core/roll_pass/deformation_unit.py
@@ -1,10 +1,8 @@
 import numpy as np
 
-from typing import List
-from shapely.geometry import LineString
 from ..unit import Unit
 from ..hooks import Hook
-from shapely.geometry import LineString
+from shapely.geometry import MultiLineString
 from typing import List
 
 
@@ -72,13 +70,13 @@ class DeformationUnit(Unit):
     class Profile(Unit.Profile):
         """Represents a profile in context of a deformation unit."""
 
-        contact_lines = Hook[List[LineString]]()
+        contact_lines = Hook[MultiLineString]()
         """List of lines that are in contact with tooling (rolls)."""
 
         contact_angles = Hook[List[np.ndarray]]()
         """List of contour angles that are in contact with tooling (rolls)."""
 
-        free_surface_lines = Hook[List[LineString]]()
+        free_surface_lines = Hook[MultiLineString]()
         """List of lines that are not in contact with tooling (rolls)."""
 
         contact_width = Hook[float]()

--- a/pyroll/core/roll_pass/hookimpls/base_roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/base_roll_pass.py
@@ -108,7 +108,7 @@ def exit_point(self: BaseRollPass):
 @BaseRollPass.Profile.contact_lines
 def contact_contour_lines(self: BaseRollPass.Profile):
     rp = self.roll_pass
-    contact_contur_lines_possible_multilinestring = [cl.intersection(self.cross_section.exterior.buffer(1e-9)) for cl in rp.contour_lines]
+    contact_contur_lines_possible_multilinestring = [cl.intersection(self.cross_section.exterior.buffer(1e-9)) for cl in rp.contour_lines.geoms]
 
     contact_contour_lines_linestring = []
     for ccl in contact_contur_lines_possible_multilinestring:
@@ -118,7 +118,7 @@ def contact_contour_lines(self: BaseRollPass.Profile):
         else:
             contact_contour_lines_linestring.append(ccl)
 
-    return contact_contour_lines_linestring
+    return MultiLineString(contact_contour_lines_linestring)
 
 
 @BaseRollPass.front_tension
@@ -133,7 +133,7 @@ def default_back_tension(self: BaseRollPass):
 
 @BaseRollPass.technologically_orientated_contour_lines
 def technologically_correctly_orientated_contour_lines(self: BaseRollPass):
-    return MultiLineString([self._get_oriented_geom(cl) for cl in self.contour_lines])
+    return MultiLineString([self._get_oriented_geom(cl) for cl in self.contour_lines.geoms])
 
 
 @BaseRollPass.OutProfile.technologically_orientated_cross_section

--- a/pyroll/core/roll_pass/hookimpls/deformation_unit.py
+++ b/pyroll/core/roll_pass/hookimpls/deformation_unit.py
@@ -99,4 +99,4 @@ def contact_contour_angles(self: DeformationUnit.Profile):
 
         return angles
 
-    return [calculate_angles(line) for line in self.contact_lines]
+    return [calculate_angles(line) for line in self.contact_lines.geoms]

--- a/pyroll/core/roll_pass/hookimpls/helpers.py
+++ b/pyroll/core/roll_pass/hookimpls/helpers.py
@@ -11,13 +11,13 @@ from ...profile.profile import refine_cross_section
 
 
 def out_cross_section(rp: TwoRollPass, width: float) -> Polygon:
-    poly = Polygon(np.concatenate([cl.coords for cl in rp.contour_lines]))
+    poly = Polygon(np.concatenate([cl.coords for cl in rp.contour_lines.geoms]))
     poly = clip_by_rect(poly, -width / 2, -math.inf, width / 2, math.inf)
     return refine_cross_section(poly)
 
 
 def out_cross_section3(rp: ThreeRollPass, width: float) -> Polygon:
-    poly = Polygon(np.concatenate([cl.coords for cl in rp.contour_lines]))
+    poly = Polygon(np.concatenate([cl.coords for cl in rp.contour_lines.geoms]))
 
     for _ in range(3):
         poly = clip_by_rect(poly, -math.inf, -math.inf, math.inf, width / 2)

--- a/pyroll/core/roll_pass/hookimpls/roll.py
+++ b/pyroll/core/roll_pass/hookimpls/roll.py
@@ -23,7 +23,7 @@ def contact_area(self: TwoRollPass.Roll):
 @ThreeRollPass.Roll.contact_area
 def contact_area3(self: ThreeRollPass.Roll):
     in_profile_local_width = self.roll_pass.in_profile.local_width(-self.roll_pass.in_profile.height / 2)
-    return (in_profile_local_width + self.roll_pass.out_profile.contact_lines[1].width) / 2 * self.contact_length
+    return (in_profile_local_width + self.roll_pass.out_profile.contact_lines.geoms[1].width) / 2 * self.contact_length
 
 
 @BaseRollPass.Roll.center

--- a/pyroll/core/roll_pass/hookimpls/three_roll_pass.py
+++ b/pyroll/core/roll_pass/hookimpls/three_roll_pass.py
@@ -62,7 +62,7 @@ def gap3_from_icd(self: ThreeRollPass) -> float:
 @ThreeRollPass.height
 def height3(self: ThreeRollPass) -> float:
     usable_contour = clip_by_rect(
-        self.contour_lines[1],
+        self.contour_lines.geoms[1],
         -self.roll.groove.usable_width / 2,
         -math.inf,
         self.roll.groove.usable_width / 2,

--- a/pyroll/core/roll_pass/three_roll_pass.py
+++ b/pyroll/core/roll_pass/three_roll_pass.py
@@ -2,7 +2,7 @@ from typing import List, cast
 
 import numpy as np
 from shapely.affinity import translate, rotate
-from shapely.geometry import LineString
+from shapely.geometry import LineString, MultiLineString
 
 from ..hooks import Hook
 from .symmetric_roll_pass import SymmetricRollPass
@@ -24,7 +24,7 @@ class ThreeRollPass(SymmetricRollPass):
         super().__init__(roll, label, **kwargs)
 
     @property
-    def contour_lines(self) -> List[LineString]:
+    def contour_lines(self) -> MultiLineString:
         if self._contour_lines:
             return self._contour_lines
 
@@ -35,7 +35,7 @@ class ThreeRollPass(SymmetricRollPass):
         left = rotate(lower, angle=60, origin=(0, 0))
         lower = rotate(lower, angle=180, origin=(0, 0))
 
-        self._contour_lines = [left, lower, right]
+        self._contour_lines = MultiLineString([left, lower, right])
         return self._contour_lines
 
     @property

--- a/pyroll/core/roll_pass/two_roll_pass.py
+++ b/pyroll/core/roll_pass/two_roll_pass.py
@@ -2,7 +2,7 @@ from typing import List, cast
 
 import numpy as np
 from shapely.affinity import translate, rotate
-from shapely.geometry import LineString
+from shapely.geometry import LineString, MultiLineString
 
 from .symmetric_roll_pass import SymmetricRollPass
 from ..roll import Roll as BaseRoll
@@ -20,14 +20,14 @@ class TwoRollPass(SymmetricRollPass):
         super().__init__(roll, label, **kwargs)
 
     @property
-    def contour_lines(self) -> List[LineString]:
+    def contour_lines(self) -> MultiLineString:
         if self._contour_lines:
             return self._contour_lines
 
         upper = translate(self.roll.contour_line, yoff=self.gap / 2)
         lower = rotate(upper, angle=180, origin=(0, 0))
 
-        self._contour_lines = [upper, lower]
+        self._contour_lines = MultiLineString([upper, lower])
         return self._contour_lines
 
     @property

--- a/tests/profiles/test_profile_contours.py
+++ b/tests/profiles/test_profile_contours.py
@@ -36,14 +36,14 @@ def test_plot_profile_contact_contours():
 
     plt.figure(dpi=300)
     plt.axes().set_aspect("equal")
-    for ccl in rp.out_profile.contact_lines:
+    for ccl in rp.out_profile.contact_lines.geoms:
         plt.plot(*ccl.xy, color='C0')
     plt.show()
     plt.close()
 
     plt.figure(dpi=300)
     # plt.axes().set_aspect("equal")
-    for cca, ccl in zip(rp.out_profile.contact_angles, rp.out_profile.contact_lines):
+    for cca, ccl in zip(rp.out_profile.contact_angles, rp.out_profile.contact_lines.geoms):
         x, y = ccl.xy
         x = x[1:-1]
         plt.plot(x, cca)

--- a/tests/profiles/test_profile_contours_3fold.py
+++ b/tests/profiles/test_profile_contours_3fold.py
@@ -35,14 +35,14 @@ def test_plot_profile_contact_contours():
 
     plt.figure(dpi=300)
     plt.axes().set_aspect("equal")
-    for ccl in rp.out_profile.contact_lines:
+    for ccl in rp.out_profile.contact_lines.geoms:
         plt.plot(*ccl.xy, color='C0')
     plt.show()
     plt.close()
 
     plt.figure(dpi=300)
     # plt.axes().set_aspect("equal")
-    for cca, ccl in zip(rp.out_profile.contact_angles, rp.out_profile.contact_lines):
+    for cca, ccl in zip(rp.out_profile.contact_angles, rp.out_profile.contact_lines.geoms):
         x, y = ccl.xy
         x = x[1:-1]
         plt.plot(x, cca)

--- a/tests/roll/test_roll_contact_areas_3fold.py
+++ b/tests/roll/test_roll_contact_areas_3fold.py
@@ -113,8 +113,8 @@ def test_plot_contact_areas(g1, g2, ip, main_fig, subplot_index):
 def contact_area(rp):
     in_profile_local_width = rp.in_profile.local_width(-rp.in_profile.height / 2)
 
-    x1 = -rp.out_profile.contact_lines[1].width / 2
-    x2 = rp.out_profile.contact_lines[1].width / 2
+    x1 = -rp.out_profile.contact_lines.geoms[1].width / 2
+    x2 = rp.out_profile.contact_lines.geoms[1].width / 2
     x3 = in_profile_local_width / 2
     x4 = -in_profile_local_width / 2
     y1 = -rp.roll.contact_length / 2

--- a/tests/roll_pass/test_roll_pass_technological_orientation.py
+++ b/tests/roll_pass/test_roll_pass_technological_orientation.py
@@ -41,18 +41,18 @@ def test_techological_orientation(tmp_path: Path, caplog):
         print(caplog.text)
 
     assert equals(
-        affinity.rotate(rp.out_profile.cross_section, 90, origin=[0, 0]),
+        affinity.rotate(rp.out_profile.cross_section, 90, origin=(0, 0)),
         rp.out_profile.technologically_orientated_cross_section
     )
     assert equals(
-        affinity.rotate(rp.contour_lines[0], 90, origin=[0, 0]),
+        affinity.rotate(rp.contour_lines.geoms[0], 90, origin=(0, 0)),
         rp.technologically_orientated_contour_lines.geoms[0]
     )
 
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
 
     ax1.plot(*rp.out_profile.cross_section.exterior.xy)
-    ax1.plot(*rp.contour_lines[0].xy, 'black', linestyle='--')
+    ax1.plot(*rp.contour_lines.geoms[0].xy, 'black', linestyle='--')
     ax1.set_title("out_profile and contour_line")
     ax1.set_aspect('equal')
     ax1.set_ylim([-0.04, 0.04])

--- a/tests/roll_pass/test_three_roll_pass.py
+++ b/tests/roll_pass/test_three_roll_pass.py
@@ -64,7 +64,7 @@ def test_contour_lines(g):
     plt.xticks(np.linspace(-50, 50, 11))
     plt.yticks(np.linspace(-50, 50, 11))
 
-    for c in rp.contour_lines:
+    for c in rp.contour_lines.geoms:
         plt.plot(*c.xy)
 
     plt.axvline(-rp.gap / 2, c="k", ls="--", lw=1)


### PR DESCRIPTION
to be in alignment with the technological hooks

report gives errors until https://github.com/pyroll-project/pyroll-report/commit/db85a49448c4d626aa9984fe556913936ea0fdfa is published