### PR TITLE
Ezdxf shapely

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pyroll-report ~= 3.0",
     "jupyter",
 ]
-features = ["plotly", "matplotlib"]
+features = ["plotly", "matplotlib", "dxf"]
 
 [envs.test]
 path = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy ~= 2.0",
     "scipy ~= 1.13",
-    "shapely ~= 2.0",
-    "ezdxf"
+    "shapely >= 2.0.6, <3.0",
+    "ezdxf-shapely ~= 1.0",
 ]
 
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "numpy ~= 2.0",
     "scipy ~= 1.13",
     "shapely >= 2.0.6, <3.0",
-    "ezdxf-shapely ~= 1.0",
 ]
 
 dynamic = ["version"]
@@ -52,6 +51,9 @@ matplotlib = [
 plotly = [
     "plotly ~= 5.18",
     "pandas ~= 2.0",
+]
+dxf = [
+    "ezdxf-shapely ~= 1.0",
 ]
 
 [project.urls]

--- a/pyroll/core/grooves/spline.py
+++ b/pyroll/core/grooves/spline.py
@@ -112,8 +112,11 @@ class SplineGroove(GrooveBase):
         :param dxf_query: query to filter the wanted geometries out of the dxf, see the ezdxf docs for details
         """
 
-        from ezdxf import readfile
-        from ezdxf_shapely import convert_all, line_merge
+        try:
+            from ezdxf import readfile
+            from ezdxf_shapely import convert_all, line_merge
+        except ImportError as e:
+            raise RuntimeError("ezdxf-shapely is required for DXF import, you may install it with the dxf extra") from e
         from shapely.affinity import translate
 
         dxf_doc = readfile(filepath)

--- a/tests/grooves/test_spline.py
+++ b/tests/grooves/test_spline.py
@@ -1,7 +1,10 @@
+import importlib.util
+
 import numpy as np
 from pyroll.core import SplineGroove
 from pathlib import Path
 import matplotlib.pyplot as plt
+import pytest
 
 points = [
     (-2, 0),
@@ -55,6 +58,7 @@ def test_spline_without_usable_width():
     assert "swedish_oval" in g.classifiers
 
 
+@pytest.mark.xfail(not importlib.util.find_spec("ezdxf_shapely"), reason="ezdxf not installed in current environment (extra)", raises=RuntimeError)
 def test_spline_from_dxf():
     script_dir = Path(__file__).resolve().parent
     dxf_file = "swedish_oval_test_groove.dxf"


### PR DESCRIPTION
- use `ezdxf-shapely` package for importing DXF data to `SplineGroove`
- make this package optional via an extra