### PR TITLE
278 add possibility to configure plotting backend instead of standard preference

### DIFF
--- a/pyroll/core/__init__.py
+++ b/pyroll/core/__init__.py
@@ -11,7 +11,7 @@ from .rotator import Rotator
 from .sequence import PassSequence
 from .hooks import Hook, HookHost, HookFunction, root_hooks
 from .disk_elements import DiskElementUnit
-from .config import Config, config
+from .config import Config, config, PlottingBackend
 
 VERSION = "3.0.0post4"
 

--- a/pyroll/core/config.py
+++ b/pyroll/core/config.py
@@ -1,19 +1,20 @@
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Optional, Iterable, Mapping, Any, Callable
 
 
 class ConfigValue:
     """Helper descriptor for storing configuration values, able to determine the value from explictly set values,
-     environment variables and default values."""
+    environment variables and default values."""
 
     def __init__(
-            self,
-            default,
-            *,
-            env_var: Optional[str] = None,
-            env_var_prefix: Optional[str] = None,
-            parser: Optional[Callable[[str], Any]] = None
+        self,
+        default,
+        *,
+        env_var: Optional[str] = None,
+        env_var_prefix: Optional[str] = None,
+        parser: Optional[Callable[[str], Any]] = None,
     ):
         self.default = default
         self.type = type(default)
@@ -26,7 +27,7 @@ class ConfigValue:
         self.owner = owner
         self.name = name
         if not self._env_var_prefix:
-            self._env_var_prefix = self.owner.__module__.upper().replace('.', '_')
+            self._env_var_prefix = self.owner.__module__.upper().replace(".", "_")
 
     @property
     def env_var(self):
@@ -83,11 +84,7 @@ class ConfigValue:
 class ConfigMeta(type):
     def to_dict(cls):
         """Return the config values of this class as dict."""
-        return {
-            n: v
-            for n, v in type(cls).__dict__.items()
-            if isinstance(v, ConfigValue)
-        }
+        return {n: v for n, v in type(cls).__dict__.items() if isinstance(v, ConfigValue)}
 
     def update(cls, d: dict[str, Any]):
         """
@@ -138,10 +135,7 @@ def config(env_var_prefix):
                 else:
                     # noinspection PyProtectedMember
                     meta_dict[n] = ConfigValue(
-                        default=v.default,
-                        env_var_prefix=env_var_prefix,
-                        env_var=v._env_var,
-                        parser=v.parser
+                        default=v.default, env_var_prefix=env_var_prefix, env_var=v._env_var, parser=v.parser
                     )
 
         meta = type(cls.__name__ + "Meta", (ConfigMeta,), meta_dict)
@@ -151,9 +145,15 @@ def config(env_var_prefix):
     return dec
 
 
+class PlottingBackend(Enum):
+    PLOTLY = 1
+    MATPLOTLIB = 2
+
+
 @config("PYROLL_CORE")
 class Config:
     """Configuration class for ``pyroll.core``."""
+
     ROLL_PASS_AUTO_ROTATION = True
     """Whether to enable automatic rotation of incoming profiles in roll passes by default."""
 
@@ -199,3 +199,6 @@ class Config:
 
     PLOT_RESOLUTION = 100
     """Resolution of plots in dots per inches (dpi)."""
+
+    PREFERRED_PLOTTING_BACKEND = PlottingBackend.PLOTLY
+    """Sets the preferred plotting backend to use when both matplotlib and plotly are installed."""

--- a/pyroll/core/repr.py
+++ b/pyroll/core/repr.py
@@ -1,8 +1,8 @@
 import html
 from abc import ABC, abstractmethod
 from io import StringIO
-from .config import Config
-from .log import global_logger
+
+from .config import Config, PlottingBackend
 
 
 class ReprMixin(ABC):
@@ -49,11 +49,18 @@ class ReprMixin(ABC):
 
         :returns: either a plotly or matplotlib figure object
         """
+        if Config.PREFERRED_PLOTTING_BACKEND == PlottingBackend.PLOTLY:
+            try:
+                return self.plot_plotly()
+            except (NotImplementedError, ImportError):
+                return self.plot_matplotlib()
+        elif Config.PREFERRED_PLOTTING_BACKEND == PlottingBackend.MATPLOTLIB:
+            try:
+                return self.plot_matplotlib()
+            except (NotImplementedError, ImportError):
+                return self.plot_plotly()
 
-        try:
-            return self.plot_plotly()
-        except (NotImplementedError, ImportError):
-            return self.plot_matplotlib()
+        raise ValueError("Invalid value given for 'Config.PREFERRED_PLOTTING_BACKEND'. Value must be a member of the pyroll.core.PlottingBackend enumeration.")
 
     def __str__(self):
         return type(self).__qualname__

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,79 @@
+from pyroll.core import Config, PlottingBackend, Profile
+
+
+def test_plot_preferred_matplotlib(monkeypatch):
+    import matplotlib.pyplot as plt
+
+    monkeypatch.setattr(Config, "PREFERRED_PLOTTING_BACKEND", PlottingBackend.MATPLOTLIB)
+    p = Profile.round(1)
+    plot = p.plot()
+    assert isinstance(plot, plt.Figure)
+
+
+def test_plot_preferred_plotly(monkeypatch):
+    import plotly.graph_objects as go
+
+    monkeypatch.setattr(Config, "PREFERRED_PLOTTING_BACKEND", PlottingBackend.PLOTLY)
+    p = Profile.round(1)
+    plot = p.plot()
+    assert isinstance(plot, go.Figure)
+
+
+def test_plot_preferred_matplotlib_block_import(monkeypatch):
+    import matplotlib.pyplot as plt
+    import plotly.graph_objects as go
+
+    def mock_fn(*args, **kwargs):
+        raise ImportError()
+
+    monkeypatch.setattr(plt.Figure, "__init__", mock_fn)
+
+    monkeypatch.setattr(Config, "PREFERRED_PLOTTING_BACKEND", PlottingBackend.MATPLOTLIB)
+    p = Profile.round(1)
+    plot = p.plot()
+    assert isinstance(plot, go.Figure)
+
+
+def test_plot_preferred_plotly_block_import(monkeypatch):
+    import matplotlib.pyplot as plt
+    import plotly.graph_objects as go
+
+    def mock_fn(*args, **kwargs):
+        raise ImportError()
+
+    monkeypatch.setattr(go.Figure, "__init__", mock_fn)
+
+    monkeypatch.setattr(Config, "PREFERRED_PLOTTING_BACKEND", PlottingBackend.PLOTLY)
+    p = Profile.round(1)
+    plot = p.plot()
+    assert isinstance(plot, plt.Figure)
+
+
+def test_plot_preferred_matplotlib_block_impl(monkeypatch):
+    import matplotlib.pyplot as plt
+    import plotly.graph_objects as go
+
+    def mock_fn(*args, **kwargs):
+        raise NotImplementedError()
+
+    monkeypatch.setattr(plt.Figure, "__init__", mock_fn)
+
+    monkeypatch.setattr(Config, "PREFERRED_PLOTTING_BACKEND", PlottingBackend.MATPLOTLIB)
+    p = Profile.round(1)
+    plot = p.plot()
+    assert isinstance(plot, go.Figure)
+
+
+def test_plot_preferred_plotly_block_impl(monkeypatch):
+    import matplotlib.pyplot as plt
+    import plotly.graph_objects as go
+
+    def mock_fn(*args, **kwargs):
+        raise NotImplementedError()
+
+    monkeypatch.setattr(go.Figure, "__init__", mock_fn)
+
+    monkeypatch.setattr(Config, "PREFERRED_PLOTTING_BACKEND", PlottingBackend.PLOTLY)
+    p = Profile.round(1)
+    plot = p.plot()
+    assert isinstance(plot, plt.Figure)


### PR DESCRIPTION
close #278 

Configuration of preferred backend now possible via the `Config` class.

```python
from pyroll.core import Config, PlottingBackend

Config.PREFERRED_PLOTTING_BACKEND = PlottingBackend.MATPLOTLIB
Config.PREFERRED_PLOTTING_BACKEND = PlottingBackend.PLOTLY
```

If this throws an `ImportError` or a `NotImplementedError` the other backend is still used if available.