### PR TITLE
Update Versioning in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,26 @@ The documentation of version 1.0 can be found [here](https://pyroll.readthedocs.
 
 ## Versions
 
-The main branch of this repository contains the code of the version 2.0 of PyRolL.
-See the [backport branch](https://github.com/pyroll-project/pyroll-core/tree/v1.0_backport) for the code of version 1.0.
-Version 1.0 is now out of support, as version 2.0 has been released.
-It is recommended to develop new plugins and extensions only for 2.0.
+The main branch of this repository contains the code of the version 3.x of PyRolL.
+
+Backport branches exist for older versions:
+
+- [v2.1.x](https://github.com/pyroll-project/pyroll-core/tree/v2.1_backport)
+- [v1.0](https://github.com/pyroll-project/pyroll-core/tree/v1.0_backport) (out of support)
+
+Versioning follows semantic versioning with the following rules:
+
+- breaking changes of core API only in major versions
+- feature releases with minor versions (enforced since 3.0)
+- bugfixes with micro versions (enforced since 3.0)
+- plugin versioning shall follow the core in major versions (so plugin v2.x works with core v2.x)
+
+It is recommended to develop new plugins and extensions only for the latest major version.
+
+### Principal Changes of Version 3.0 Respective to 2.0
+
+- Refactoring of the roll pass class inheritance hierarchy to enable for support of asymmetric passes.
+- Introduction of pre- and post-processors to simplify implementation of some models. 
 
 ### Principal Changes of Version 2.0 Respective to 1.0
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The documentation of version 1.0 can be found [here](https://pyroll.readthedocs.
 ## Versions
 
 The main branch of this repository contains the code of the version 3.x of PyRolL.
-
 Backport branches exist for older versions:
 
 - [v2.1.x](https://github.com/pyroll-project/pyroll-core/tree/v2.1_backport)
@@ -46,9 +45,26 @@ Backport branches exist for older versions:
 Versioning follows semantic versioning with the following rules:
 
 - breaking changes of core API only in major versions
-- feature releases with minor versions (enforced since 3.0)
-- bugfixes with micro versions (enforced since 3.0)
+- feature releases with minor versions
+- bugfixes with micro versions
 - plugin versioning shall follow the core in major versions (so plugin v2.x works with core v2.x)
+
+As breaking changes are considered:
+
+- removal of public API functions / classes
+- non backwards compatible signature changes of public API functions / classes
+- removal of hooks
+- removal of hook implementations in the core
+- changes in hook implementations that would likely break plugin implementations
+
+As features are considered:
+
+- new public API functions / classes
+- backwards compatible signature changes of public API functions / classes
+- new hooks on existing units / profiles
+- new hook implementations in the core
+
+All other changes not considered as breaking change or feature are considered as bugfixes.
 
 It is recommended to develop new plugins and extensions only for the latest major version.
 


### PR DESCRIPTION
Please check and notice also the new rules for versioning.

Especially feature releases: we do not have to spare minor release versions. Making a new minor with each feature release enables easier dependency management in plugins and extensions.